### PR TITLE
[DM-28114] Update dev dependencies, fix duplicate logging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
         python:
           - 3.7
           - 3.8
+          - 3.9
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.4
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,30 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.4.0
   hooks:
   - id: check-yaml
   - id: check-toml
 
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.4
-  hooks:
-  - id: seed-isort-config
-    args: [--exclude=docs/.*\.py, --application-directories, src]
-
-- repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21-2
+- repo: https://github.com/pycqa/isort
+  rev: 5.7.0
   hooks:
   - id: isort
     additional_dependencies:
       - toml
 
 - repo: https://github.com/ambv/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
   - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.5.0-1
+  rev: v1.9.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==19.10b0]
+    additional_dependencies: [black==20.8b1]
     args: [-l, "79", -t, py37]
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.8.4
   hooks:
   - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+0.1.1 (2021-01-14)
+==================
+
+- Fix duplicated log output when logging is configured multiple times.
+- Update dependencies.
+
 0.1.0 (2020-02-26)
 ==================
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -97,8 +97,7 @@ Inside a request handler, get the logging from the ``"safir/logger"`` key of the
 
    @routes.get("/")
    async def get_index(request: web.Request) -> web.Response:
-       """GET /<path>/ (the app's external root).
-       """
+       """GET /<path>/ (the app's external root)."""
        logger = request["safir/logger"]
        logger.info("My message", somekey=42)
 

--- a/docs/storage-keys.rst
+++ b/docs/storage-keys.rst
@@ -23,8 +23,7 @@ In a request context, you can access application data, regardless of whether it 
 
    @routes.get("/")
    async def get_index(request: web.Request) -> web.Response:
-       """GET /<path>/ (the app's external root).
-       """
+       """GET /<path>/ (the app's external root)."""
        metadata = request.config_dict["safir/metadata"]
        data = {"_metadata": metadata}
        return web.json_response(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,5 @@ exclude = '''
 
 [tool.isort]
 multi_line_output = 3
-known_first_party = "safir"
-known_third_party = ["aiohttp", "pytest", "setuptools", "structlog"]
+known_first_party = ["safir", "tests"]
 skip = ["docs/conf.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,coverage-report,typing,lint
+envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [testenv]
@@ -26,8 +26,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py37
-    py38
+    py
 commands =
     coverage combine
     coverage report

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Intended Audience :: Developers
     Natural Language :: English
     Operating System :: POSIX

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,11 @@ where = src
 
 [options.extras_require]
 dev =
-    pre-commit==2.0.1
-    pytest==5.3.5
-    coverage[toml]==5.0.3
-    flake8==3.7.9
-    mypy==0.761
+    pre-commit==2.9.3
+    pytest==6.2.1
+    coverage[toml]==5.3.1
+    flake8==3.8.4
+    mypy==0.790
     pytest-aiohttp==0.3.0
     # documentation
     documenteer>=0.5,<0.6

--- a/src/safir/__init__.py
+++ b/src/safir/__init__.py
@@ -3,12 +3,11 @@
 __all__ = ["__version__", "version_info"]
 
 import sys
-from typing import List
 
 if sys.version_info < (3, 8):
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 else:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 
 
 __version__: str
@@ -20,7 +19,7 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"
 
-version_info: List[str] = __version__.split(".")
+version_info = __version__.split(".")
 """The decomposed version, split across "``.``."
 
 Use this for version comparison.

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -13,6 +13,8 @@ __all__ = ["configure_logging", "response_logger", "get_response_logger"]
 
 
 if TYPE_CHECKING:
+    from typing import Any, List
+
     from structlog._config import BoundLoggerLazyProxy
 
 
@@ -144,7 +146,7 @@ def configure_logging(
 
     if profile == "production":
         # JSON-formatted logging
-        processors = [
+        processors: List[Any] = [
             structlog.stdlib.filter_by_level,
             structlog.stdlib.add_logger_name,
             structlog.stdlib.add_log_level,

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -141,6 +141,7 @@ def configure_logging(
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setFormatter(logging.Formatter("%(message)s"))
     logger = logging.getLogger(name)
+    logger.handlers = []
     logger.addHandler(stream_handler)
     logger.setLevel(log_level.upper())
 

--- a/src/safir/metadata.py
+++ b/src/safir/metadata.py
@@ -17,7 +17,14 @@ else:
     from importlib.metadata import metadata
 
 if TYPE_CHECKING:
-    from email.message import Message
+    if sys.version_info < (3, 8):
+        # mypy doesn't understand the PackageMetadata type returned by the
+        # importlib_metadata backport supports dict operations.  In Python 3.8
+        # and later, it's an email.message.Message, so declare it explicitly
+        # as that type but alias that to Any on older versions.
+        Message = Any
+    else:
+        from email.message import Message
 
 
 def setup_metadata(
@@ -77,7 +84,7 @@ def setup_metadata(
          "documentation_url": "https://github.com/lsst-sqre/safirdemo"
        }
     """
-    pkg_metadata = metadata(package_name)
+    pkg_metadata: Message = metadata(package_name)
 
     try:
         config = app["safir/config"]

--- a/src/safir/middleware.py
+++ b/src/safir/middleware.py
@@ -15,6 +15,7 @@ __all__ = ["bind_logger"]
 
 if TYPE_CHECKING:
     from typing import Awaitable, Callable
+
     from aiohttp.web.web_response import Request, StreamResponse
 
     Handler = Callable[[Request], Awaitable[StreamResponse]]
@@ -129,7 +130,9 @@ async def bind_logger(request: Request, handler: Handler) -> StreamResponse:
 
     logger = structlog.get_logger(logger_name)
     logger = logger.new(
-        request_id=str(uuid.uuid4()), path=request.path, method=request.method,
+        request_id=str(uuid.uuid4()),
+        path=request.path,
+        method=request.method,
     )
 
     # Add the logger to the ContextVar

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -10,6 +10,7 @@ import structlog
 from safir.logging import configure_logging
 
 if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
     from _pytest.logging import LogCaptureFixture
 
 
@@ -61,3 +62,15 @@ def test_configure_logging_level(caplog: LogCaptureFixture) -> None:
     # debug-level shouldn't get logged
     logger.debug("DEBUG message")
     assert len(caplog.record_tuples) == 1
+
+
+def test_duplicate_handlers(capsys: CaptureFixture[str]) -> None:
+    """Test that configuring logging more than once doesn't duplicate logs."""
+    configure_logging(name="myapp", profile="production", log_level="info")
+    configure_logging(name="myapp", profile="production", log_level="info")
+
+    logger = structlog.get_logger("myapp")
+
+    logger.info("INFO not duplicate message")
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 1

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -18,7 +18,16 @@ else:
     from importlib.metadata import metadata
 
 if TYPE_CHECKING:
-    from email.message import Message
+    if sys.version_info < (3, 8):
+        # mypy doesn't understand the PackageMetadata type returned by the
+        # importlib_metadata backport supports dict operations.  In Python 3.8
+        # and later, it's an email.message.Message, so declare it explicitly
+        # as that type but alias that to Any on older versions.
+        from typing import Any
+
+        Message = Any
+    else:
+        from email.message import Message
 
     from aiohttp.pytest_plugin.test_utils import TestClient
     from aiohttp.web.web_response import Request, StreamResponse

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -19,8 +19,9 @@ else:
 
 if TYPE_CHECKING:
     from email.message import Message
-    from aiohttp.web.web_response import Request, StreamResponse
+
     from aiohttp.pytest_plugin.test_utils import TestClient
+    from aiohttp.web.web_response import Request, StreamResponse
 
 
 @pytest.fixture(scope="session")
@@ -29,22 +30,19 @@ def safir_metadata() -> Message:
 
 
 def test_get_project_url(safir_metadata: Message) -> None:
-    """Test the get_project_url function using Safir's own metadata.
-    """
+    """Test the get_project_url function using Safir's own metadata."""
     source_url = get_project_url(safir_metadata, "Source code")
     assert source_url == "https://github.com/lsst-sqre/safir"
 
 
 def test_get_project_url_missing(safir_metadata: Message) -> None:
-    """Test that get_project_url returns None for a missing URL.
-    """
+    """Test that get_project_url returns None for a missing URL."""
     source_url = get_project_url(safir_metadata, "Nonexistent")
     assert source_url is None
 
 
 async def test_setup_metadata(aiohttp_client: TestClient) -> None:
-    """Test setup_metadata in normal usage.
-    """
+    """Test setup_metadata in normal usage."""
 
     async def handler(request: Request) -> StreamResponse:
         m = request.config_dict["safir/metadata"]
@@ -73,8 +71,7 @@ async def test_setup_metadata(aiohttp_client: TestClient) -> None:
 
 
 async def test_setup_metadata_missing(aiohttp_client: TestClient) -> None:
-    """Test setup_metadata if safir/config hasn't been added to the app.
-    """
+    """Test setup_metadata if safir/config hasn't been added to the app."""
 
     def create_app() -> web.Application:
         app = web.Application()

--- a/tests/middleware_test.py
+++ b/tests/middleware_test.py
@@ -12,9 +12,9 @@ from safir.logging import configure_logging
 from safir.middleware import bind_logger
 
 if TYPE_CHECKING:
-    from aiohttp.web.web_response import Request, StreamResponse
-    from aiohttp.pytest_plugin.test_utils import TestClient
     from _pytest.logging import LogCaptureFixture
+    from aiohttp.pytest_plugin.test_utils import TestClient
+    from aiohttp.web.web_response import Request, StreamResponse
 
 
 async def test_bind_logger(


### PR DESCRIPTION
Update dev and pre-commit dependencies and apply corresponding
changes.

Each time safir was configured, it stacked another handler into
the safir logger.  This meant that if logging was repeatedly
configured in the same Python process, all log output to stdout
would be duplicated.  This primarily affected test suites, where
each test would reinitialize logging.  The impact was that failed
tests from files with lots of tests would have log out duplicated
a number of times equal to the number of tests, which made it hard
to find the error or understand the output.

Avoid this by clearing the handlers in the safir logger each time
logging is configured to ensure that only the single, wanted handler
is added.