### PR TITLE
[DM-30689] Optionally add a timestamp to log messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+0.2.0 (2021-06-10)
+==================
+
+- ``configure_logging`` now supports an optional ``add_timestamp`` parameter (false by default) that adds a timestamp to each log message.
+- Update dependencies.
+
 0.1.1 (2021-01-14)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,9 +58,9 @@ dev =
 
 [flake8]
 max-line-length = 79
-# Ignored rules for Black
-# E203 whitespace before ':'
-ignore = E203
+# E203: whitespace before :, flake8 disagrees with PEP-8
+# W503: line break after binary operator, flake8 disagrees with PEP-8
+ignore = E203, W503
 exclude =
     docs/conf.py
 

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -90,23 +90,27 @@ def configure_logging(
     name : `str`
         Name of the logger, which is typically the name of your application's
         root namespace.
-    profile : `str`
+    profile : `str`, optional
         The name of the application profile:
 
         development
             Log messages are formatted for easier reading on the terminal.
         production
             Log messages are formatted as JSON objects.
-    log_level : `str`
-        The log level, in string form:
+
+        The default is ``production``.
+    log_level : `str`, optional
+        The log level, in string form (case-insensitive):
 
         - ``DEBUG``
         - ``INFO``
         - ``WARNINGS``
         - ``ERROR``
+
+        The default is ``INFO``.
     add_timestamp : `bool`
-        Whether to add an ISO-format timestamp to each log message.  Default
-        is `False`.
+        Whether to add an ISO-format timestamp to each log message.  The
+        default is `False`.
 
     Notes
     -----

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -77,7 +77,11 @@ def get_response_logger() -> BoundLoggerLazyProxy:
 
 
 def configure_logging(
-    *, name: str, profile: str = "production", log_level: str = "info"
+    *,
+    name: str,
+    profile: str = "production",
+    log_level: str = "info",
+    add_timestamp: bool = False,
 ) -> None:
     """Configure logging and structlog.
 
@@ -100,6 +104,9 @@ def configure_logging(
         - ``INFO``
         - ``WARNINGS``
         - ``ERROR``
+    add_timestamp : `bool`
+        Whether to add an ISO-format timestamp to each log message.  Default
+        is `False`.
 
     Notes
     -----
@@ -145,30 +152,27 @@ def configure_logging(
     logger.addHandler(stream_handler)
     logger.setLevel(log_level.upper())
 
+    processors: List[Any] = [
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+    ]
+    if add_timestamp:
+        processors.append(structlog.processors.TimeStamper(fmt="iso"))
+    processors.extend(
+        [
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+        ]
+    )
     if profile == "production":
         # JSON-formatted logging
-        processors: List[Any] = [
-            structlog.stdlib.filter_by_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-            structlog.processors.JSONRenderer(),
-        ]
+        processors.append(structlog.processors.JSONRenderer())
     else:
         # Key-value formatted logging
-        processors = [
-            structlog.stdlib.filter_by_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-            structlog.dev.ConsoleRenderer(),
-        ]
+        processors.append(structlog.dev.ConsoleRenderer())
 
     structlog.configure(
         processors=processors,


### PR DESCRIPTION
Kubernetes tracks the timestamp of each output line internally, so
this is not strictly necessary for our Kubernetes services, but
Argo CD doesn't display that timestamp and other log aggregation may
not necessarily.  Add an optional argument to configure_logging to
allow an application to request a timestamp be added to each log
message.