### PR TITLE
[DM-28130] Delay AsyncClient creation and allow recreation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
-2.0.1 (unreleased)
+2.0.1 (2021-06-24)
 ==================
 
 - Defer creation of ``httpx.AsyncClient`` until the first time it is requested.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.0.1 (unreleased)
+==================
+
+- Defer creation of ``httpx.AsyncClient`` until the first time it is requested.
+  Allow re-creation after ``aclose()``, which makes it easier to write test suites.
+
 2.0.0 (2021-06-21)
 ==================
 

--- a/src/safir/dependencies/http_client.py
+++ b/src/safir/dependencies/http_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import httpx
 
 __all__ = [
@@ -35,19 +37,19 @@ class HTTPClientDependency:
     """
 
     def __init__(self) -> None:
-        self.http_client = httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT)
+        self.http_client: Optional[httpx.AsyncClient] = None
 
     def __call__(self) -> httpx.AsyncClient:
         """Return the cached ``httpx.AsyncClient``."""
+        if not self.http_client:
+            self.http_client = httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT)
         return self.http_client
 
     async def aclose(self) -> None:
-        """Close the ``httpx.AsyncClient``.
-
-        It is an error to use the dependency after this method has been
-        called. It should only be called during application shutdown.
-        """
-        await self.http_client.aclose()
+        """Close the ``httpx.AsyncClient``."""
+        if self.http_client:
+            await self.http_client.aclose()
+            self.http_client = None
 
 
 http_client_dependency = HTTPClientDependency()


### PR DESCRIPTION
The approach of creating one AsyncClient on startup and destroying
that one client without a way of recreating it on shutdown works
fine for the application when run normally, but fails in test
scenarios that reuse the application.

Instead, defer creation of the AsyncClient until the first time
it's requested, clear it on aclose(), and recreate it if it's asked
for again.  This allows applications to aclose() the client on
shutdown but still work when the same app object is reused for
multiple tests.