### PR TITLE
Update for structlog 21.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.0.2 (unreleased)
+==================
+
+- Require structlog 21.2.0 and adjust logger configuration of exception handling for the expectations of that version.
+
 2.1.0 (2021-08-09)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     httpx
     pydantic
     starlette
-    structlog
+    structlog>=21.2.0
 
 [options.packages.find]
 where = src

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -116,12 +116,12 @@ def configure_logging(
     processors.extend(
         [
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
         ]
     )
     if profile == "production":
         # JSON-formatted logging
+        processors.append(structlog.processors.format_exc_info)
         processors.append(structlog.processors.JSONRenderer())
     else:
         # Key-value formatted logging


### PR DESCRIPTION
Per the release notes of structlog 21.2.0:

* To implement pretty exceptions (see Changes below),
  structlog.dev.ConsoleRenderer now formats exceptions itself.
  Make sure to remove format_exc_info from your processor chain if
  you configure structlog manually.

Do this.  Also adapt the test suite to handle color logging for
the dev logger (which is now enabled by default) and explicitly
check exception handling for both loggers.