### PR TITLE
[DM-32520] Adjust for new httpx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.0.1
   hooks:
   - id: check-yaml
   - id: check-toml
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.7.0
+  rev: 5.10.0
   hooks:
   - id: isort
     additional_dependencies:
@@ -18,13 +18,13 @@ repos:
   - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.9.1
+  rev: v1.11.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==21.10b0]
     args: [-l, "79", -t, py37]
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 4.0.1
   hooks:
   - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - toml
 
 - repo: https://github.com/ambv/black
-  rev: 20.8b1
+  rev: 21.10b0
   hooks:
   - id: black
 
@@ -21,7 +21,7 @@ repos:
   rev: v1.9.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==20.8b1]
+    additional_dependencies: [black==21.10b0]
     args: [-l, "79", -t, py37]
 
 - repo: https://gitlab.com/pycqa/flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.2.0 (2021-11-09)
+==================
+
+- Restore previous ``http_client_dependency`` behavior by enabling following redirects by default.
+  This adjusts for the change of defaults in httpx 0.20.0.
+
 2.1.1 (2021-10-29)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     fastapi
-    httpx
+    httpx>=0.20.0
     pydantic
     starlette
     structlog>=21.2.0
@@ -46,18 +46,18 @@ where = src
 [options.extras_require]
 dev =
     asgi-lifespan==1.0.1
-    pre-commit==2.15.0
-    pytest==6.2.5
     coverage[toml]==6.1.1
     flake8==4.0.1
     mypy==0.910
+    pre-commit==2.15.0
+    pytest==6.2.5
     pytest-asyncio==0.16.0
-    pytest-httpx==0.14.0
+    respx==0.18.2
     # documentation
     documenteer>=0.5,<0.7
     lsst-sphinx-bootstrap-theme<0.3
-    sphinx-prompt
     sphinx-automodapi==0.13
+    sphinx-prompt
 
 [flake8]
 max-line-length = 79

--- a/src/safir/dependencies/http_client.py
+++ b/src/safir/dependencies/http_client.py
@@ -24,6 +24,9 @@ seconds. Users of this dependency can always lower it if needed.
 class HTTPClientDependency:
     """Provides an ``httpx.AsyncClient`` as a dependency.
 
+    The resulting client will have redirects enabled and the default timeout
+    increased to 20 seconds.
+
     Notes
     -----
     The application must call ``http_client_dependency.aclose()`` as part of a
@@ -42,7 +45,9 @@ class HTTPClientDependency:
     async def __call__(self) -> httpx.AsyncClient:
         """Return the cached ``httpx.AsyncClient``."""
         if not self.http_client:
-            self.http_client = httpx.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT)
+            self.http_client = httpx.AsyncClient(
+                timeout=DEFAULT_HTTP_TIMEOUT, follow_redirects=True
+            )
         return self.http_client
 
     async def aclose(self) -> None:

--- a/tests/dependencies/http_client_test.py
+++ b/tests/dependencies/http_client_test.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Dict, List
 
 import pytest
+import respx
 from asgi_lifespan import LifespanManager
 from fastapi import Depends, FastAPI
-from httpx import AsyncClient
-from pytest_httpx import HTTPXMock
+from httpx import AsyncClient, Response
 
 from safir.dependencies.http_client import http_client_dependency
 
@@ -19,9 +19,9 @@ def non_mocked_hosts() -> List[str]:
 
 
 @pytest.mark.asyncio
-async def test_http_client(httpx_mock: HTTPXMock) -> None:
+async def test_http_client(respx_mock: respx.Router) -> None:
     app = FastAPI()
-    httpx_mock.add_response(url="https://www.google.com")
+    respx_mock.get("https://www.google.com").mock(return_value=Response(200))
 
     @app.get("/")
     async def handler(

--- a/tests/dependencies/http_client_test.py
+++ b/tests/dependencies/http_client_test.py
@@ -8,7 +8,7 @@ import pytest
 import respx
 from asgi_lifespan import LifespanManager
 from fastapi import Depends, FastAPI
-from httpx import AsyncClient, Response
+from httpx import AsyncClient
 
 from safir.dependencies.http_client import http_client_dependency
 
@@ -21,7 +21,7 @@ def non_mocked_hosts() -> List[str]:
 @pytest.mark.asyncio
 async def test_http_client(respx_mock: respx.Router) -> None:
     app = FastAPI()
-    respx_mock.get("https://www.google.com").mock(return_value=Response(200))
+    respx_mock.get("https://www.google.com").respond(200)
 
     @app.get("/")
     async def handler(


### PR DESCRIPTION
- Enable redirects by default, restoring the previous behavior
- Depend on the version of httpx adding the new redirect behavior
- Switch from pytest-httpx to respx for testing
- Install `py.typed` so that mypy knows to use type annotations in this library
- Update pre-commit hooks