### PR TITLE
[DM-32941] Change JSON logging for compatibility with Google Log Explorer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.3.0 (unreleased)
+==================
+
+- When logging in JSON format, use ``severity`` instead of ``level`` for the log level for compatibility with Google Log Explorer.
+- In the FastAPI ``logger_dependency``, add log information about the incoming requst in a format compatible with Google Log Explorer.
+
 2.2.0 (2021-11-09)
 ==================
 

--- a/src/safir/dependencies/logger.py
+++ b/src/safir/dependencies/logger.py
@@ -22,9 +22,15 @@ class LoggerDependency:
     The following additional information will be included:
 
     * A UUID for the request
-    * The method and path of the request
-    * The IP address of the client (as ``remote``)
+    * The method and URL of the request
+    * The IP address of the client
     * The ``User-Agent`` header of the request, if any.
+
+    The results of `~safir.middleware.XForwardedMiddleware` will be honored if
+    present. The last three pieces of information will be added using naming
+    consistent with the expectations of Google Log Explorer so that the
+    request information will be liftedn into the appropriate JSON fields for
+    complex log queries.
     """
 
     def __init__(self) -> None:
@@ -41,15 +47,39 @@ class LoggerDependency:
         if not self.logger:
             self.logger = structlog.get_logger(logging.logger_name)
         assert self.logger
-        logger = self.logger.new(
-            request_id=str(uuid.uuid4()),
-            path=request.url.path,
-            method=request.method,
-            remote=request.client.host,
-        )
+
+        # Construct the request URL, honoring X-Forwarded-* if the
+        # XForwardedMiddleware is in use.
+        if getattr(request.state, "forwarded_host", None):
+            if request.state.forwarded_proto:
+                proto = request.state.forwarded_proto
+            else:
+                proto = request.url.scheme
+            if request.state.forwarded_host:
+                host = request.state.forwarded_host
+            else:
+                host = request.url.hostname
+            url = f"{proto}://{host}{request.url.path}"
+            if request.url.query:
+                url += "?" + request.url.query
+        else:
+            url = str(request.url)
+
+        # Construct the httpRequest logging data (compatible with the format
+        # expected by Google Log Explorer).
+        request_data = {
+            "requestMethod": request.method,
+            "requestUrl": url,
+            "remoteIp": request.client.host,
+        }
         user_agent = request.headers.get("User-Agent")
         if user_agent:
-            logger = logger.bind(user_agent=user_agent)
+            request_data["userAgent"] = user_agent
+
+        logger = self.logger.new(
+            httpRequest=request_data,
+            request_id=str(uuid.uuid4()),
+        )
         return logger
 
 

--- a/tests/dependencies/logger_test.py
+++ b/tests/dependencies/logger_test.py
@@ -41,12 +41,12 @@ async def test_logger(caplog: LogCaptureFixture) -> None:
     assert len(caplog.record_tuples) == 1
     assert json.loads(caplog.record_tuples[0][2]) == {
         "event": "something",
-        "level": "info",
         "logger": "myapp",
         "method": "GET",
         "param": "value",
         "path": "/",
         "remote": "127.0.0.1",
         "request_id": ANY,
+        "severity": "info",
         "user_agent": "some-user-agent/1.0",
     }

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -92,7 +92,7 @@ def test_configure_logging_production(caplog: LogCaptureFixture) -> None:
         "myapp",
         logging.INFO,
         '{"answer": 42, "event": "Hello world", "logger": "myapp", '
-        '"level": "info"}',
+        '"severity": "info"}',
     )
 
 
@@ -118,7 +118,7 @@ def test_configure_logging_prod_timestamp(caplog: LogCaptureFixture) -> None:
         "answer": 42,
         "event": "Hello world",
         "logger": "myapp",
-        "level": "info",
+        "severity": "info",
         "timestamp": ANY,
     }
     assert data["timestamp"].endswith("Z")
@@ -189,7 +189,7 @@ def test_production_exception_logging(caplog: LogCaptureFixture) -> None:
         "exception": ANY,
         "foo": "bar",
         "logger": "myapp",
-        "level": "error",
+        "severity": "error",
     }
     assert "Traceback (most recent call last)" in data["exception"]
     assert '"this is some exception"' in data["exception"]


### PR DESCRIPTION
- Log the log level as `severity` instead of `level` when using JSON format
- Log HTTP request information in an `httpRequest` key using the Google-supported fields