### PR TITLE
[DM-33121] Change expected patch body for custom objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.4.1 (2022-01-14)
+==================
+
+- In the Kubernetes mock API, change the expected body for ``patch_namespaced_custom_object_status`` to reflect the need to send a JSON patch for the entirety of the ``/status`` path in order to work around a kubernetes_asyncio bug.
+
 2.4.0 (2022-01-13)
 ==================
 

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -179,7 +179,7 @@ class MockKubernetesApi(Mock):
         namespace: str,
         plural: str,
         name: str,
-        body: Dict[str, Any],
+        body: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
         self._maybe_error(
             "patch_namespaced_custom_object_status",
@@ -191,11 +191,10 @@ class MockKubernetesApi(Mock):
         )
         key = f"{group}/{version}/{plural}"
         obj = copy.deepcopy(self._get_object(namespace, key, name))
-        assert "status" in body
-        assert "conditions" in body["status"]
-        if "status" not in obj:
-            obj["status"] = {}
-        obj["status"]["conditions"] = body["status"]["conditions"]
+        for change in body:
+            assert change["op"] == "replace"
+            assert change["path"] == "/status"
+            obj["status"] = change["value"]
         self._store_object(namespace, key, name, obj, replace=True)
         return obj
 


### PR DESCRIPTION
Update patch_namespaced_custom_object_status to expect a JSON
patch rather than a merge patch, enabling a workaround for a bug
in kubernetes-asyncio.
