### PR TITLE
[DM-33244] Add basic support for list_namespaced_pod testing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+2.4.2 (unreleased)
+==================
+
+- Add a very basic and limited implementation of ``list_namespaced_pod`` to ``safir.testing.kubernetes``.
+
 2.4.1 (2022-01-14)
 ==================
 


### PR DESCRIPTION
Not a full implementation of the API.  Currently, it requires a
field_selector be given to restrict the result to a single pod,
since that's what's required for testing moneypenny.

Stop inheriting from `Mock`, since it causes weird errors and
doesn't appear to be doing anything useful for us.