### PR TITLE
[DM-33604] Improve handling of X-Forwarded-Proto

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+3.0.0 (unreleased)
+==================
+
+- ``XForwardedMiddleware`` no longer sets ``forwaded_proto`` in the request state and instead directly updates the request scope so that subsequent handlers and middleware believe the request scheme is that given by an ``X-Forwarded-Proto`` header.
+  This fixes the scheme returned by other request methods and attributes such as ``url_for`` in cases where the service is behind an ingress that terminates TLS.
+
 2.4.2 (2022-01-24)
 ==================
 

--- a/docs/x-forwarded.rst
+++ b/docs/x-forwarded.rst
@@ -54,8 +54,14 @@ The IP address stored in the first element of the tuple will be the original cli
 The port number associated with the client is not updated and will be the client port on the proxy.
 (This port number is generally not useful.)
 
-If the application needs additional information about the request, the middleware will store the original client protocol in ``request.state.forwarded_proto`` and the original value of the ``Host`` header in the client request in ``request.state.forwarded_host``.
-Either or both of these may be ``None`` if ``X-Forwarded-Proto`` or ``X-Forwarded-Host`` are missing or invalid.
+If the necessary ``X-Forwarded-Proto`` header is present and appears to be valid, the scheme of the request URL will be set to the original scheme used by the client before the request handler is called.
+This will cause ``request.url_for()`` and similar request methods and attributes to use the scheme of the original request rather than the scheme seen by the server.
+(Generally this means using ``https`` instead of ``http``.)
+If there are multiple ``X-Forwarded-Proto`` headers, there is no way of knowing which is correct, so they are all ignored.
+
+The middleware will store the original value of the ``Host`` header in the client request in ``request.state.forwarded_host``.
+(This is usually not needed, since NGINX generally preserves the ``Host`` header of the original request when proxying.)
+This may be ``None`` if ``X-Forwarded-Host`` is missing or invalid.
 If there are multiple ``X-Forwarded-Host`` headers, there is no way of knowing which is correct, so they are all ignored.
 
 Note that ``X-Forwarded-Host``, unlike the other headers, does not accumulate values as it passes through multiple proxies.

--- a/src/safir/dependencies/logger.py
+++ b/src/safir/dependencies/logger.py
@@ -48,28 +48,11 @@ class LoggerDependency:
             self.logger = structlog.get_logger(logging.logger_name)
         assert self.logger
 
-        # Construct the request URL, honoring X-Forwarded-* if the
-        # XForwardedMiddleware is in use.
-        if getattr(request.state, "forwarded_host", None):
-            if request.state.forwarded_proto:
-                proto = request.state.forwarded_proto
-            else:
-                proto = request.url.scheme
-            if request.state.forwarded_host:
-                host = request.state.forwarded_host
-            else:
-                host = request.url.hostname
-            url = f"{proto}://{host}{request.url.path}"
-            if request.url.query:
-                url += "?" + request.url.query
-        else:
-            url = str(request.url)
-
         # Construct the httpRequest logging data (compatible with the format
         # expected by Google Log Explorer).
         request_data = {
             "requestMethod": request.method,
-            "requestUrl": url,
+            "requestUrl": str(request.url),
             "remoteIp": request.client.host,
         }
         user_agent = request.headers.get("User-Agent")

--- a/tests/dependencies/logger_test.py
+++ b/tests/dependencies/logger_test.py
@@ -74,6 +74,7 @@ async def test_logger_xforwarded(caplog: LogCaptureFixture) -> None:
         r = await client.get(
             "/",
             headers={
+                "Host": "foo.example.com",
                 "User-Agent": "",
                 "X-Forwarded-For": "10.10.10.10",
                 "X-Forwarded-Proto": "https",

--- a/tests/middleware/x_forwarded_test.py
+++ b/tests/middleware/x_forwarded_test.py
@@ -25,15 +25,16 @@ async def test_ok() -> None:
 
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
-        assert request.state.forwarded_host == "foo.example.com"
-        assert request.state.forwarded_proto == "https"
         assert request.client.host == "10.10.10.10"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "https://foo.example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:
         r = await client.get(
             "/",
             headers={
+                "Host": "foo.example.com",
                 "X-Forwarded-For": "10.10.10.10, 11.11.11.11",
                 "X-Forwarded-Proto": "https, http",
                 "X-Forwarded-Host": "foo.example.com",
@@ -48,9 +49,9 @@ async def test_defaults() -> None:
 
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
-        assert request.state.forwarded_host == "foo.example.com"
-        assert request.state.forwarded_proto == "http"
         assert request.client.host == "192.168.0.1"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "http://example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:
@@ -72,8 +73,8 @@ async def test_no_forwards() -> None:
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
         assert not request.state.forwarded_host
-        assert not request.state.forwarded_proto
         assert request.client.host == "127.0.0.1"
+        assert request.url == "http://example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:
@@ -87,9 +88,9 @@ async def test_all_filtered() -> None:
 
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
-        assert request.state.forwarded_host == "foo.example.com"
-        assert request.state.forwarded_proto == "https"
         assert request.client.host == "10.10.10.10"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "https://example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:
@@ -110,9 +111,9 @@ async def test_one_proto() -> None:
 
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
-        assert request.state.forwarded_host == "foo.example.com"
-        assert request.state.forwarded_proto == "https"
         assert request.client.host == "10.10.10.10"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "https://example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:
@@ -134,8 +135,8 @@ async def test_no_proto_or_host() -> None:
     @app.get("/")
     async def handler(request: Request) -> Dict[str, str]:
         assert not request.state.forwarded_host
-        assert not request.state.forwarded_proto
         assert request.client.host == "10.10.10.10"
+        assert request.url == "http://example.com/"
         return {}
 
     async with AsyncClient(app=app, base_url="http://example.com") as client:


### PR DESCRIPTION
In the XForwardedMiddleware, rather than storing the forwarded
scheme from X-Forwarded-Proto in the request state, simply update
the scope of the request so that Starlette will think the incoming
scheme was the sheme from X-Forwarded-Proto.  Drop the state
variable that was previously set.

This will ensure that other Starlette functions such as url_for
will pick up the correct scheme and thus generate URLs that
correctly use https even if the service is behind an ingress that
terminates TLS.