### PR TITLE
[DM-33604] Add FastAPI dependencies for Gafaelfawr auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Change log
 
 - ``XForwardedMiddleware`` no longer sets ``forwaded_proto`` in the request state and instead directly updates the request scope so that subsequent handlers and middleware believe the request scheme is that given by an ``X-Forwarded-Proto`` header.
   This fixes the scheme returned by other request methods and attributes such as ``url_for`` in cases where the service is behind an ingress that terminates TLS.
+- Add new FastAPI dependencies ``auth_dependency`` and ``auth_logger_dependency`` from the ``safir.dependencies.gafaelfawr`` module.
+  ``auth_dependency`` returns the username of the user authenticated via Gafaelfawr (pulled from the ``X-Auth-Request-User`` header.
+  ``auth_logger_dependency`` returns the same logger as ``logger_dependency`` but with the ``user`` parameter bound to the username from ``auth_dependency``.
 
 2.4.2 (2022-01-24)
 ==================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,9 @@ API reference
 .. automodapi:: safir
    :include-all-objects:
 
+.. automodapi:: safir.dependencies.gafaelfawr
+   :include-all-objects:
+
 .. automodapi:: safir.dependencies.http_client
    :include-all-objects:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ rst_epilog = """
 .. _structlog: http://www.structlog.org/en/stable/
 .. _templatekit: https://templatekit.lsst.io
 .. _tox: https://tox.readthedocs.io/en/latest/
+.. _Gafaelfawr: https://gafaelfawr.lsst.io/
 """
 
 # Extensions =================================================================

--- a/docs/gafaelfawr.rst
+++ b/docs/gafaelfawr.rst
@@ -18,7 +18,7 @@ To get that username, use the `~safir.dependencies.gafaelfawr.auth_dependency` F
 
 
    @app.get("/route")
-   async def get_rounte(user: str = Depends(auth_dependench)) -> Dict[str, str]:
+   async def get_rounte(user: str = Depends(auth_dependency)) -> Dict[str, str]:
        # Route implementation using user.
        return {"some": "data"}
 

--- a/docs/gafaelfawr.rst
+++ b/docs/gafaelfawr.rst
@@ -1,0 +1,36 @@
+###################################
+Requiring Gafaelfawr authentication
+###################################
+
+Safir provides two FastAPI dependencies intended for applications designed to run behind a Kubernetes ingress configured to authenticate requests with `Gafaelfawr`_.
+
+Getting the authenticated user
+==============================
+
+Gafaelfawr sets the ``X-Auth-Request-User`` HTTP header to the username of the user authenticated with a Gafaelfawr token.
+To get that username, use the `~safir.dependencies.gafaelfawr.auth_dependency` FastAPI dependency, as follows:
+
+.. code-block:: python
+
+   from fastapi import Depends
+
+   from safir.dependencies.gafaelfawr import auth_dependency
+
+
+   @app.get("/route")
+   async def get_rounte(user: str = Depends(auth_dependench)) -> Dict[str, str]:
+       # Route implementation using user.
+       return {"some": "data"}
+
+If the request does not have the Gafaelfawr header set, it will be rejected by FastAPI with a 422 status code.
+
+To safely use this dependency, the application must be configured so that all requests will go through an ingress configured to use Gafaelfawr.
+If this is not the case (if, for example, the application is directly exposed to the Internet), the person sending the request could include the header that would be set by Gafaelfawr and assert any identity that they chose, which is obviously insecure.
+
+Including the authenticated user in logging
+===========================================
+
+To include the authenticated user in log messages from a handler, use the `~safir.dependencies.gafaelfawr.auth_logger_dependency` dependency instead of the `~safir.dependencies.logger.logger_dependency`.
+It works the same way, but additionally binds the ``user`` context variable to the authenticated user, obtained via `~safir.dependencies.gafaelfawr.auth_dependency`.
+
+For more details, see :ref:`logging-in-handlers`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Guides
    :maxdepth: 2
 
    http-client
+   gafaelfawr
    kubernetes
    logging
    x-forwarded

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -94,6 +94,12 @@ The log message will look something like:
      "user_agent": "some-user-agent/1.0"
    }
 
+Authenticated routes
+--------------------
+
+If the route is protected by `Gafaelfawr`_, instead use ``auth_logger_dependency`` imported from ``safir.dependencies.gafaelfawr``.
+This will behave the same except that it will bind the additional context field ``user`` to the authenticated user as asserted by the headers added by Gafaelfawr.
+
 Binding extra context to the logger
 -----------------------------------
 

--- a/src/safir/dependencies/gafaelfawr.py
+++ b/src/safir/dependencies/gafaelfawr.py
@@ -1,0 +1,24 @@
+"""Gafaelfawr authentication dependencies."""
+
+from fastapi import Depends, Header
+from structlog.stdlib import BoundLogger
+
+from .logger import logger_dependency
+
+
+async def auth_dependency(x_auth_request_user: str = Header(...)) -> str:
+    """Retrieve authentication information from HTTP headers.
+
+    Intended for use with applications protected by Gafaelfawr, this retrieves
+    authentication information from headers added to the incoming request by
+    the Gafaelfawr ``auth_request`` NGINX subhandler.
+    """
+    return x_auth_request_user
+
+
+async def auth_logger_dependency(
+    user: str = Depends(auth_dependency),
+    logger: BoundLogger = Depends(logger_dependency),
+) -> BoundLogger:
+    """Logger bound to the authenticated user."""
+    return logger.bind(user=user)

--- a/tests/dependencies/gafaelfawr_test.py
+++ b/tests/dependencies/gafaelfawr_test.py
@@ -1,0 +1,74 @@
+"""Test the Gafaelfawr auth FastAPI dependencies."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+from unittest.mock import ANY
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+from fastapi import Depends, FastAPI
+from httpx import AsyncClient
+from structlog.stdlib import BoundLogger
+
+from safir.dependencies.gafaelfawr import (
+    auth_dependency,
+    auth_logger_dependency,
+)
+from safir.logging import configure_logging
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency() -> None:
+    app = FastAPI()
+
+    @app.get("/")
+    async def handler(user: str = Depends(auth_dependency)) -> Dict[str, str]:
+        return {"user": user}
+
+    async with AsyncClient(app=app, base_url="https://example.com") as client:
+        r = await client.get("/")
+        assert r.status_code == 422
+
+        r = await client.get("/", headers={"X-Auth-Request-User": "someuser"})
+        assert r.status_code == 200
+        assert r.json() == {"user": "someuser"}
+
+
+@pytest.mark.asyncio
+async def test_auth_logger_dependency(caplog: LogCaptureFixture) -> None:
+    configure_logging(name="myapp", profile="production", log_level="info")
+
+    app = FastAPI()
+
+    @app.get("/")
+    async def handler(
+        logger: BoundLogger = Depends(auth_logger_dependency),
+    ) -> Dict[str, str]:
+        logger.info("something")
+        return {}
+
+    caplog.clear()
+    async with AsyncClient(app=app, base_url="https://example.com") as client:
+        r = await client.get("/", headers={"User-Agent": ""})
+        assert r.status_code == 422
+
+        r = await client.get(
+            "/", headers={"User-Agent": "", "X-Auth-Request-User": "someuser"}
+        )
+        assert r.status_code == 200
+
+    assert len(caplog.record_tuples) == 1
+    assert json.loads(caplog.record_tuples[0][2]) == {
+        "event": "something",
+        "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "https://example.com/",
+            "remoteIp": "127.0.0.1",
+        },
+        "logger": "myapp",
+        "request_id": ANY,
+        "severity": "info",
+        "user": "someuser",
+    }


### PR DESCRIPTION
Add new auth_dependency and auth_logger_dependency FastAPI
dependencies for applications protected by Gafaelfawr.  The former
returns the authenticated user from the header set by Gafaelfawr,
and the latter wraps logger_dependency and adds the authenticated
user as a bound context variable.