### PR TITLE
[DM-33604] Upgrade dependencies during make init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: init
 init:
-	pip install -e ".[db,dev,kubernetes]"
-	pip install tox tox-docker pre-commit
+	pip install --upgrade pip tox tox-docker pre-commit
+	pip install --upgrade -e ".[db,dev,kubernetes]"
 	pre-commit install


### PR DESCRIPTION
Add the --upgrade flag to upgrade to the latest versions of
dependencies, and explicitly upgrade pip.  This more closely
follows the practices of other Python packages we maintain.