### PR TITLE
[DM-33604] Add run_with_asyncio wrapper and init docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Change log
   The session creation functions optionally support a health check to ensure the database schema has been initialized.
 - Add new FastAPI dependency ``db_session_dependency`` that creates a task-local async SQLAlchemy session and optionally manages the database transaction for that session.
 - Add utility functions ``datetime_from_db`` and ``datetime_to_db`` to convert between timezone-naive UTC datetimes stored in a database and timezone-aware UTC datetimes used elsewhere in a program.
+- Add a ``run_with_async`` decorator that runs the decorated async function synchronously.
+  This is primarily useful for decorating Click command functions (for a command-line interface) that need to make async calls.
 
 2.4.2 (2022-01-24)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@ rst_epilog = """
 .. _Gafaelfawr: https://gafaelfawr.lsst.io/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _asyncpg: https://magicstack.github.io/asyncpg/current/
+.. _Click: https://click.palletsprojects.com/
+.. _Uvicorn: https://www.uvicorn.org/
 """
 
 # Extensions =================================================================

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -1,0 +1,54 @@
+"""Utility functions for asyncio code."""
+
+from __future__ import annotations
+
+import asyncio
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+__all__ = ["run_with_asyncio"]
+
+
+def run_with_asyncio(f: Callable[..., Awaitable[T]]) -> Callable[..., T]:
+    """Run the decorated function with `asyncio.run`.
+
+    Intended to be used as a decorator around an async function that needs to
+    be run in a sync context.  The decorated function will be run with
+    `asyncio.run` when invoked.  The caller must not already be inside an
+    asyncio task.
+
+    Examples
+    --------
+    An application that uses Safir and `Click`_ may use the following Click
+    command function to initialize a database.
+
+    .. code-block:: python
+
+       import structlog
+       from safir.asyncio import run_with_asyncio
+       from safir.database import initialize_database
+
+       from .config import config
+       from .schema import Base
+
+
+       @main.command()
+       @run_with_asyncio
+       async def init() -> None:
+           logger = structlog.get_logger(config.safir.logger_name)
+           engine = await initialize_database(
+               config.database_url,
+               config.database_password,
+               logger,
+               schema=Base.metadata,
+           )
+           await engine.dispose()
+    """
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper

--- a/tests/asyncio_test.py
+++ b/tests/asyncio_test.py
@@ -1,0 +1,13 @@
+"""Tests for asyncio utility functions."""
+
+from __future__ import annotations
+
+from safir.asyncio import run_with_asyncio
+
+
+def test_run_with_asyncio() -> None:
+    @run_with_asyncio
+    async def some_async_function() -> str:
+        return "some result"
+
+    assert some_async_function() == "some result"


### PR DESCRIPTION
We're using variations on this in several packages now to allow
the command-line code to run asyncio functions, so add it to Safir
rather than copy/pasting the code everywhere.

Use this wrapper to document a command-line way of requesting
database initialization, and document the practice of running that
init command during each pod startup.