### PR TITLE
[DM-33604] Fix all documentation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,25 @@ intersphinx_mapping = {
 intersphinx_timeout = 10.0  # seconds
 intersphinx_cache_limit = 5  # days
 
+nitpick_ignore = [
+    # Ignore missing cross-references for modules that don't provide
+    # intersphinx.  The documentation itself should use double-quotes instead
+    # of single-quotes to not generate a reference, but automatic references
+    # are generated from the type signatures and can't be avoided.
+    ("py:class", "fastapi.applications.FastAPI"),
+    ("py:class", "kubernetes_asyncio.client.models.v1_config_map.V1ConfigMap"),
+    ("py:class", "kubernetes_asyncio.client.models.v1_pod.V1Pod"),
+    ("py:class", "kubernetes_asyncio.client.models.v1_pod_list.V1PodList"),
+    ("py:class", "kubernetes_asyncio.client.models.v1_secret.V1Secret"),
+    ("py:class", "kubernetes_asyncio.client.models.v1_status.V1Status"),
+    ("py:class", "httpx.AsyncClient"),
+    ("py:class", "pydantic.main.BaseModel"),
+    ("py:class", "pydantic.utils.Representation"),
+    ("py:class", "starlette.middleware.base.BaseHTTPMiddleware"),
+    ("py:class", "starlette.requests.Request"),
+    ("py:class", "starlette.responses.Response"),
+]
+
 # Linkcheck builder ==========================================================
 
 linkcheck_retries = 2
@@ -155,7 +174,10 @@ napoleon_use_rtype = True
 autosummary_generate = True
 
 automodapi_toctreedirnm = "api"
-automodsumm_inherited_members = True
+
+# Inheriting docstrings from parents by default creates huge amounts of noise
+# in Pydantic.  Use the :inherited-members: flag when this is needed.
+automodsumm_inherited_members = False
 
 # Docstrings for classes and methods are inherited from parents.
 autodoc_inherit_docstrings = True

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -171,8 +171,8 @@ The session returned by the dependency will then not have an open transaction, a
 Handling datetimes in database tables
 =====================================
 
-When a database column is defined using the SQLAlchemy ORM using the `~sqlalchemy.DateTime` generic type, it cannot store a timezone.
-The SQL standard type `~sqlalchemy.DATETIME` may include a timezone with some database backends, but it is database-specific.
+When a database column is defined using the SQLAlchemy ORM using the `~sqlalchemy.types.DateTime` generic type, it cannot store a timezone.
+The SQL standard type `~sqlalchemy.types.DATETIME` may include a timezone with some database backends, but it is database-specific.
 It is therefore normally easier to store times in the database in UTC without timezone information.
 
 However, `~datetime.datetime` objects in regular Python code should always be timezone-aware and use the UTC timezone.
@@ -323,11 +323,11 @@ Safir itself does not depend on psycopg2, even with the ``db`` extra, since most
 Setting an isolation level
 ==========================
 
-`~safir.database.create_database_engine`, `~safir.database.create_sync_session`, and the ``initialize`` method of `~safir.dependencies.db_sesssion.db_sesssion_dependency` take an optional ``isolation_level`` argument that can be used to set a non-default isolation level.
+`~safir.database.create_database_engine`, `~safir.database.create_sync_session`, and the ``initialize`` method of `~safir.dependencies.db_session.db_session_dependency` take an optional ``isolation_level`` argument that can be used to set a non-default isolation level.
 If given, this parameter is passed through to the underlying SQLAlchemy engine.
 See `the SQLAlchemy isolation level documentation <https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#setting-transaction-isolation-levels-dbapi-autocommit>`__ for more information.
 
 You may have to set a custom isolation level, such as ``REPEATABLE READ``, if you have multiple simultaneous database writers and need to coordinate their writes to ensure consistent results.
 
 Be aware that most situations in which you need to set a custom isolation level will also result in valid transactions raising exceptions indicating that they need to be retried, because another writer changed the database while the transaction was in progress.
-You therefore will probably need to disable transaction management for the `~safir.dependencies.db_sesssion.db_sesssion_dependency` by passing ``manage_transactions=False`` to the ``initialize`` method and then manage transactions directly in the code (usually inside retry loops).
+You therefore will probably need to disable transaction management for the `~safir.dependencies.db_session.db_session_dependency` by passing ``manage_transactions=False`` to the ``initialize`` method and then manage transactions directly in the code (usually inside retry loops).

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -239,7 +239,7 @@ def create_sync_session(
 
     Returns
     -------
-    session : `sqlalchemy.orm.scoped_session`
+    session : `sqlalchemy.orm.scoping.scoped_session`
         The database session proxy.  This manages a separate session per
         thread and therefore should be thread-safe.
     """

--- a/src/safir/dependencies/gafaelfawr.py
+++ b/src/safir/dependencies/gafaelfawr.py
@@ -5,6 +5,11 @@ from structlog.stdlib import BoundLogger
 
 from .logger import logger_dependency
 
+__all__ = [
+    "auth_dependency",
+    "auth_logger_dependency",
+]
+
 
 async def auth_dependency(x_auth_request_user: str = Header(...)) -> str:
     """Retrieve authentication information from HTTP headers.

--- a/src/safir/dependencies/logger.py
+++ b/src/safir/dependencies/logger.py
@@ -26,11 +26,10 @@ class LoggerDependency:
     * The IP address of the client
     * The ``User-Agent`` header of the request, if any.
 
-    The results of `~safir.middleware.XForwardedMiddleware` will be honored if
-    present. The last three pieces of information will be added using naming
-    consistent with the expectations of Google Log Explorer so that the
-    request information will be liftedn into the appropriate JSON fields for
-    complex log queries.
+    The last three pieces of information will be added using naming consistent
+    with the expectations of Google Log Explorer so that the request
+    information will be liftedn into the appropriate JSON fields for complex
+    log queries.
     """
 
     def __init__(self) -> None:

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import Any, List, Optional
 
 import structlog
 from structlog.stdlib import add_log_level
-
-if TYPE_CHECKING:
-    from typing import Any, List, Optional
-
-    from structlog.types import EventDict
+from structlog.types import EventDict
 
 __all__ = ["add_log_severity", "configure_logging", "logger_name"]
 
@@ -44,7 +40,8 @@ def add_log_severity(
     logger : `logging.Logger`
         The wrapped logger object.
     method_name : `str`
-        The name of the wrapped method (``warning`` or ``error`, for example).
+        The name of the wrapped method (``warning`` or ``error``, for
+        example).
     event_dict : `structlog.types.EventDict`
         Current context and current event. This parameter is also modified in
         place, matching the normal behavior of structlog processors.

--- a/src/safir/metadata.py
+++ b/src/safir/metadata.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
+from email.message import Message
 from importlib.metadata import metadata
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
-
-if TYPE_CHECKING:
-    from email.message import Message
 
 __all__ = ["Metadata", "get_metadata", "get_project_url"]
 

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-from ipaddress import ip_address
-from typing import TYPE_CHECKING
+from ipaddress import _BaseAddress, _BaseNetwork, ip_address
+from typing import Awaitable, Callable, List, Optional
 
-from fastapi import Request, Response
+from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
-
-if TYPE_CHECKING:
-    from ipaddress import _BaseAddress, _BaseNetwork
-    from typing import Awaitable, Callable, List, Optional
-
-    from fastapi import FastAPI
 
 __all__ = ["XForwardedMiddleware"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,4 +64,4 @@ commands = pre-commit run --all-files
 [testenv:docs]
 description = Build documentation (HTML) with Sphinx.
 commands =
-    sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
Add a nitpick_ignore configuration for all the types seen in type
signatures that do not provide intersphinx, and disable automatic
inheritence of members from parent classes to avoid tons of noise
from Pydantic.  Use the cleaner warning list to fix various typos,
incorrect references, and other API documentation bugs.  Remove the
if TYPE_CHECKING conditional in a few files so that Sphinx can
properly resolve the references.

Make documentation warnings fatal so that we can maintain the
clean build going forward.