### PR TITLE
[DM-33662] Refinements to the database support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Change log
   ``auth_logger_dependency`` returns the same logger as ``logger_dependency`` but with the ``user`` parameter bound to the username from ``auth_dependency``.
 - Add utility functions to initialize a database and create a sync or async session.
   The session creation functions optionally support a health check to ensure the database schema has been initialized.
-- Add new FastAPI dependency ``db_session_dependency`` that creates a task-local async SQLAlchemy session and optionally manages the database transaction for that session.
+- Add new FastAPI dependency ``db_session_dependency`` that creates a task-local async SQLAlchemy session.
 - Add utility functions ``datetime_from_db`` and ``datetime_to_db`` to convert between timezone-naive UTC datetimes stored in a database and timezone-aware UTC datetimes used elsewhere in a program.
 - Add a ``run_with_async`` decorator that runs the decorated async function synchronously.
   This is primarily useful for decorating Click command functions (for a command-line interface) that need to make async calls.

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -164,16 +164,18 @@ Then, any handler that needs a database session can depend on the `~safir.depend
 Transaction management
 ----------------------
 
-When using the Safir database dependency, you must pay careful attention to managing transactions.
-
+The application must manage transactions when using the Safir database dependency.
 SQLAlchemy will automatically start a transaction if you perform any database operation using a session (including read-only operations).
 If that transaction is not explicitly ended, `asyncpg`_ may leave it open, which will cause database deadlocks and other problems.
-Due to an as-yet-unexplained interaction with FastAPI 0.74 and later, managing the transaction inside the database session dependency does not work; calling ``await session.commit()`` there, either explicitly or implicitly via a context manager, immediately fails by raising ``asyncio.CancelledError`` and the transaction is not committed or closed.
-The program using the Safir database dependency must therefore explicitly manage transactions itself and ensure that all transactions are committed or rolled back before a handler returns its result.
 
-Generally the easiest way to do this is to manage the transaction in the handler function, as in the ``get_index`` function in the example above.
+Generally it's best to manage the transaction in the handler function (see the ``get_index`` example, above).
 Wrap all code that may make database calls in an ``async with session.begin()`` block.
 This will open a transaction, commit the transaction at the end of the block, and roll back the transaction if the block raises an exception.
+
+.. note::
+
+   Due to an as-yet-unexplained interaction with FastAPI 0.74 and later, managing the transaction inside the database session dependency does not work.
+   Calling ``await session.commit()`` there, either explicitly or implicitly via a context manager, immediately fails by raising ``asyncio.CancelledError`` and the transaction is not committed or closed.
 
 Handling datetimes in database tables
 =====================================

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -61,12 +61,11 @@ For applications using `Click`_ (the recommended way to implement a command-line
    @run_with_asyncio
    async def init() -> None:
        logger = structlog.get_logger(config.logger_name)
-       engine = await initialize_database(
-           config.database_url,
-           config.database_password,
-           logger,
-           schema=Base.metadata,
-           reset=reset,
+       engine = create_database_engine(
+           config.database_url, config.database_password
+       )
+       await initialize_database(
+           engine, logger, schema=Base.metadata, reset=reset
        )
        await engine.dispose()
 
@@ -290,7 +289,7 @@ For example:
    import pytest_asyncio
    from asgi_lifespan import LifespanManager
    from fastapi import FastAPI
-   from safir.database import initialize_database
+   from safir.database import create_database_engine, initialize_database
 
    from application import main
    from application.config import config
@@ -300,13 +299,10 @@ For example:
    @pytest_asyncio.fixture
    async def app() -> AsyncIterator[FastAPI]:
        logger = structlog.get_logger(config.logger_name)
-       engine = await initialize_database(
-           config.database_url,
-           config.database_password,
-           logger,
-           schema=Base.metadata,
-           reset=True,
+       engine = create_database_engine(
+           config.database_url, config.database_password
        )
+       await initialize_database(engine, logger, schema=Base.metadata, reset=True)
        await engine.dispose()
        async with LifespanManager(main.app):
            yield main.app

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -278,21 +278,18 @@ def create_sync_session(
 
 
 async def initialize_database(
-    url: str,
-    password: Optional[str],
+    engine: AsyncEngine,
     logger: BoundLogger,
     *,
     schema: MetaData,
     reset: bool = False,
-) -> AsyncEngine:
+) -> None:
     """Create and initialize a new database.
 
     Parameters
     ----------
-    url : `str`
-        Database connection URL, not including the password.
-    password : `str` or `None`
-        Database connection password.
+    engine : `sqlalchemy.ext.asyncio.AsyncEngine`
+        Database engine to use.  Create with `create_database_engine`.
     logger : ``structlog.stdlib.BoundLogger``
         Logger used to report problems
     schema : `sqlalchemy.sql.schema.MetaData`
@@ -306,14 +303,6 @@ async def initialize_database(
         Useful when running tests with an external database.  Default is
         `False`.
 
-    Returns
-    -------
-    engine : `sqlalchemy.ext.asyncio.AsyncEngine`
-        Database engine for the initialized database.  This may be used by the
-        caller to perform any additional necessary database initialization not
-        included in the schema, such as adding default table rows.  The engine
-        must then be closed with ``await engine.dispose()``.
-
     Raises
     ------
     DatabaseInitializationError
@@ -322,7 +311,6 @@ async def initialize_database(
     """
     success = False
     error = None
-    engine = create_database_engine(url, password)
     for _ in range(5):
         try:
             async with engine.begin() as conn:
@@ -343,4 +331,3 @@ async def initialize_database(
         logger.error(msg)
         await engine.dispose()
         raise DatabaseInitializationError(error)
-    return engine

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -48,15 +48,9 @@ class DatabaseSessionDependency:
         self._engine: Optional[AsyncEngine] = None
         self._override_engine: Optional[AsyncEngine] = None
         self._session: Optional[async_scoped_session] = None
-        self._manage_transactions = True
 
     async def __call__(self) -> AsyncIterator[async_scoped_session]:
-        """Create a database session and open a transaction.
-
-        By default, this implements a policy of one request equals one
-        transaction, which is closed when that request returns.  To disable
-        managed transactions, pass ``manage_transactions=False`` to the
-        `initialize` method.
+        """Return the database session manager.
 
         Returns
         -------
@@ -64,11 +58,7 @@ class DatabaseSessionDependency:
             The newly-created session.
         """
         assert self._session, "db_session_dependency not initialized"
-        if self._manage_transactions:
-            async with self._session.begin():
-                yield self._session
-        else:
-            yield self._session
+        yield self._session
 
         # Following the recommendations in the SQLAlchemy documentation, each
         # session is scoped to a single web request.  However, this all uses
@@ -88,7 +78,6 @@ class DatabaseSessionDependency:
         password: Optional[str],
         *,
         isolation_level: Optional[_IsolationLevel] = None,
-        manage_transactions: bool = True,
     ) -> None:
         """Initialize the session dependency.
 
@@ -101,15 +90,7 @@ class DatabaseSessionDependency:
         isolation_level : `str`, optional
             If specified, sets a non-default isolation level for the database
             engine.
-        manage_transactions : `bool`, optional
-            Whether the dependency should open a new transaction for each
-            request and commit that transaction at the end of the request.
-            This is the default behavior; to manage transactions manually,
-            set this parameter to `False`.  (Disabling managed transactions
-            may be necessary if the application database code has to retry
-            failed transactions due to a non-default isolation level.)
         """
-        self._manage_transactions = manage_transactions
         if self._override_engine:
             self._session = await create_async_session(self._override_engine)
         else:
@@ -123,9 +104,8 @@ class DatabaseSessionDependency:
 
         Intended for testing, this allows the test suite to configure a single
         database engine and share it across all of the tests, benefiting from
-        connection pooling for a test speed-up.  In the Gafaelfawr test suite,
-        sharing an engine for all tests improved the time it took to run the
-        full test suite by XX%.
+        connection pooling for a minor test speed-up.  (This is not
+        significant enough to bother with except for an extensive test suite.)
 
         Parameters
         ----------

--- a/tests/dependencies/db_session_test.py
+++ b/tests/dependencies/db_session_test.py
@@ -14,7 +14,11 @@ from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
 from sqlalchemy.orm import declarative_base
 
-from safir.database import create_async_session, initialize_database
+from safir.database import (
+    create_async_session,
+    create_database_engine,
+    initialize_database,
+)
 from safir.dependencies.db_session import db_session_dependency
 
 TEST_DATABASE_URL = os.environ["TEST_DATABASE_URL"]
@@ -34,13 +38,8 @@ class User(Base):
 @pytest.mark.asyncio
 async def test_session() -> None:
     logger = structlog.get_logger(__name__)
-    engine = await initialize_database(
-        TEST_DATABASE_URL,
-        TEST_DATABASE_PASSWORD,
-        logger,
-        schema=Base.metadata,
-        reset=True,
-    )
+    engine = create_database_engine(TEST_DATABASE_URL, TEST_DATABASE_PASSWORD)
+    await initialize_database(engine, logger, schema=Base.metadata, reset=True)
     session = await create_async_session(engine, logger)
     await db_session_dependency.initialize(
         TEST_DATABASE_URL, TEST_DATABASE_PASSWORD
@@ -87,13 +86,8 @@ async def test_session() -> None:
 @pytest.mark.asyncio
 async def test_unmanaged_transactions() -> None:
     logger = structlog.get_logger(__name__)
-    engine = await initialize_database(
-        TEST_DATABASE_URL,
-        TEST_DATABASE_PASSWORD,
-        logger,
-        schema=Base.metadata,
-        reset=True,
-    )
+    engine = create_database_engine(TEST_DATABASE_URL, TEST_DATABASE_PASSWORD)
+    await initialize_database(engine, logger, schema=Base.metadata, reset=True)
     await engine.dispose()
     await db_session_dependency.initialize(
         TEST_DATABASE_URL, TEST_DATABASE_PASSWORD, manage_transactions=False


### PR DESCRIPTION
After testing with the applications that use this database support, some parts of the API were clunky or didn't allow enough connection sharing to try to optimize test suite execution times. FastAPI 0.74 also introduced a new problem that made the managed transactions mode fail. Make the following changes:

- Change `iniitalize_database` to take the engine as a parameter, rather than create a new engine that the caller is responsible for freeing. The caller should call `create_database_engine` first instead, and let it handle authentication.
- Allow overriding the engine used by `db_session_dependency` in case an application wants to share a connection pool among tests.
- Remove managed transactions mode for `db_session_dependency` since it doesn't work with FastAPI 0.74 and later with uvicorn and asyncpg.