### PR TITLE
DM-33627: Retain port setting in safir.database

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+3.0.1 (2022-02-24)
+==================
+
+- ``safir.database`` retains the port in the database URL, if provided.
+
 3.0.0 (2022-02-23)
 ==================
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -59,7 +59,7 @@ For applications using `Click`_ (the recommended way to implement a command-line
        "--reset", is_flag=True, help="Delete all existing database data."
    )
    @run_with_asyncio
-   async def init() -> None:
+   async def init(reset: bool) -> None:
        logger = structlog.get_logger(config.logger_name)
        engine = create_database_engine(
            config.database_url, config.database_password

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -70,6 +70,8 @@ def _build_database_url(
             parsed_url = parsed_url._replace(scheme="postgresql+asyncpg")
         if password:
             netloc = f"{parsed_url.username}:{password}@{parsed_url.hostname}"
+            if parsed_url.port:
+                netloc = f"{netloc}:{parsed_url.port}"
             parsed_url = parsed_url._replace(netloc=netloc)
         url = parsed_url.geturl()
     return url

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -79,9 +79,19 @@ def test_build_database_url() -> None:
     assert url == "postgresql+asyncpg://foo@127.0.0.1/foo"
 
     url = _build_database_url(
+        "postgresql://foo@127.0.0.1:5432/foo", None, is_async=True
+    )
+    assert url == "postgresql+asyncpg://foo@127.0.0.1:5432/foo"
+
+    url = _build_database_url(
         "postgresql://foo@127.0.0.1/foo", "otherpass", is_async=True
     )
     assert url == "postgresql+asyncpg://foo:otherpass@127.0.0.1/foo"
+
+    url = _build_database_url(
+        "postgresql://foo@127.0.0.1:5433/foo", "otherpass", is_async=True
+    )
+    assert url == "postgresql+asyncpg://foo:otherpass@127.0.0.1:5433/foo"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This allows non-standard Postgres port settings to be respected. I sometimes use a different port for either the "dev" or "test" containers to avoid conflicts when running tests while also running a dev instance of the app locally.

Also fixes a typo in the "init" CLI function example.