### PR TITLE
[DM-33981] Unpin dependencies, test weekly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: "pip"
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
@@ -64,6 +65,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.8
+          cache: "pip"
 
       - name: Install Graphviz
         run: sudo apt-get install graphviz
@@ -100,6 +102,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.8
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
@@ -66,6 +67,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Install Graphviz
         run: sudo apt-get install graphviz
@@ -103,6 +105,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install Graphviz
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: "pip"
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,0 +1,38 @@
+# This is a separate run of the Python test suite that doesn't cache the tox
+# environment and runs from a schedule.  The purpose is to test compatibility
+# with the latest versions of all modules Safir depends on, since Safir (being
+# a library) does not pin its dependencies.
+
+name: Periodic CI
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.3
+
+      - name: Install tox
+        run: pip install tox tox-docker
+
+      - name: Run tox
+        run: tox -e py,typing

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Intended Audience :: Developers
     Natural Language :: English
     Operating System :: POSIX
@@ -48,20 +49,20 @@ db =
     asyncpg
     sqlalchemy[asyncio]
 dev =
-    asgi-lifespan==1.0.1
-    coverage[toml]==6.3.2
-    flake8==4.0.1
-    mypy==0.940
-    pre-commit==2.17.0
-    psycopg2==2.9.3
-    pytest==7.1.0
-    pytest-asyncio==0.18.2
-    respx==0.19.2
-    sqlalchemy[mypy]==1.4.32
+    asgi-lifespan
+    coverage[toml]
+    flake8
+    mypy
+    pre-commit
+    psycopg2
+    pytest
+    pytest-asyncio
+    respx
+    sqlalchemy[mypy]
     # documentation
-    documenteer>=0.5,<0.7
-    lsst-sphinx-bootstrap-theme<0.3
-    sphinx-automodapi==0.14.1
+    documenteer
+    lsst-sphinx-bootstrap-theme
+    sphinx-automodapi
     sphinx-prompt
 kubernetes =
     kubernetes_asyncio


### PR DESCRIPTION
Unpin development dependencies to avoid dependabot needing to send
PRs for dependency updates every week.

Check compatibility with the latest released versions by running a
separate CI job weekly that does not cache the tox environments and
thus will use the latest versions of all dependencies.

Enable the normally-not-used setup-python caching so that we can share
a pip cache between the regular CI job and the periodic job.

Bump the version used for documentation and PyPI workflows to the latest
Python release.