### PR TITLE
[DM-34097] Fix database passwords with special characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+3.0.2 (unreleased)
+==================
+
+- Fix handling of passwords containing special characters such as ``@`` and ``/`` in ``safir.database``.
+
 3.0.1 (2022-02-24)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
-3.0.2 (unreleased)
+3.0.2 (2022-03-25)
 ==================
 
 - Fix handling of passwords containing special characters such as ``@`` and ``/`` in ``safir.database``.

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ image = postgres:latest
 ports =
     5432:5432/tcp
 environment =
-    POSTGRES_PASSWORD=INSECURE-PASSWORD
+    POSTGRES_PASSWORD=INSECURE@%PASSWORD/
     POSTGRES_USER=safir
     POSTGRES_DB=safir
     PGPORT=5432
@@ -37,7 +37,7 @@ commands =
     coverage run -m pytest {posargs}
 setenv =
     TEST_DATABASE_URL = postgresql://safir@127.0.0.1/safir
-    TEST_DATABASE_PASSWORD = INSECURE-PASSWORD
+    TEST_DATABASE_PASSWORD = INSECURE@%PASSWORD/
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
Be more careful about URL quoting when rewriting database URLs in
safir.database so that passwords containing characters with special
meaning in URLs (@, /) are handled correctly.

urlparse doesn't undo quoting, so use a test database password
containing various special characters for a thorough test.