### PR TITLE
[DM-34859] Support pool_pre_ping for create_database_engine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change log
 .. Headline template:
    X.Y.Z (YYYY-MM-DD)
 
+3.1.0 (unreleased)
+==================
+
+- Add ``pool_pre_ping`` argument to ``create_database_engine``.
+  If set, this is passed down to SQLAlchemy to enable testing of the database connection each time a connection is checked out of the connection pool.
+  This may be useful to work around TCP connection timeouts between an application and the database.
+
 3.0.3 (2022-05-16)
 ==================
 

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -132,6 +132,7 @@ def create_database_engine(
     password: Optional[str],
     *,
     isolation_level: Optional[_IsolationLevel] = None,
+    pool_pre_ping: bool = False,
 ) -> AsyncEngine:
     """Create a new async database engine.
 
@@ -144,6 +145,10 @@ def create_database_engine(
     isolation_level : `str`, optional
         If specified, sets a non-default isolation level for the database
         engine.
+    pool_pre_ping : `bool`, optional
+        If set to `True`, test each connection from the pool before using it
+        for a new session.  This means a database query is run each time a
+        session is created.
 
     Returns
     -------
@@ -159,10 +164,15 @@ def create_database_engine(
     url = _build_database_url(url, password, is_async=True)
     if isolation_level:
         return create_async_engine(
-            url, future=True, isolation_level=isolation_level
+            url,
+            future=True,
+            isolation_level=isolation_level,
+            pool_pre_ping=pool_pre_ping,
         )
     else:
-        return create_async_engine(url, future=True)
+        return create_async_engine(
+            url, future=True, pool_pre_ping=pool_pre_ping
+        )
 
 
 async def create_async_session(


### PR DESCRIPTION
Support passing pool_pre_ping down to the underlying
create_async_engine API call.  This tells SQLAlchemy to test the
connection whenever a new session is created.

SLAC is seeing a problem where connections are reset when used
during Gafaelfawr login to create a new token while querying the
database to determine if the user is an admin (which is the first
database query that would be done during the login process).  This
seems to be due to a connection timeout, and setting this parameter
should work around the problem.

Setting this unconditionally would be simpler, but it means a
database query every time a session is created, which for some
applications would significantly increase the database traffic and
thus have potential performance issues.  Make it optional so that
the application can choose (and possibly make it configurable in
the application as well).