### PR TITLE
DM-35119: Fixes for current mypy / type checking

### DIFF
--- a/src/safir/metadata.py
+++ b/src/safir/metadata.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-import sys
 from email.message import Message
 from importlib.metadata import metadata
-from typing import Optional, cast
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -67,10 +66,7 @@ def get_metadata(*, package_name: str, application_name: str) -> Metadata:
     project_urls, Source code
         Used as the ``respository_url``.
     """
-    if sys.version_info >= (3, 10):
-        pkg_metadata = cast(Message, metadata(package_name))
-    else:
-        pkg_metadata = metadata(package_name)
+    pkg_metadata = metadata(package_name)
     return Metadata(
         name=application_name,
         version=pkg_metadata.get("Version", "0.0.0"),

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -87,10 +87,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         # Update the request's understanding of the client IP.  This uses an
         # undocumented interface; hopefully it will keep working.
-        if request.client:
-            request.scope["client"] = (client, request.client.port)
-        else:
-            request.scope["client"] = (client, None)
+        request.scope["client"] = (client, request.client.port)
 
         # Ideally this should take the scheme corresponding to the entry in
         # X-Forwarded-For that was chosen, but some proxies (the Kubernetes

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-import sys
 from email.message import Message
 from importlib.metadata import metadata
-from typing import cast
 
 import pytest
 
@@ -15,10 +13,7 @@ from safir.metadata import get_metadata, get_project_url
 
 @pytest.fixture(scope="session")
 def safir_metadata() -> Message:
-    if sys.version_info >= (3, 10):
-        return cast(Message, metadata("safir"))
-    else:
-        return metadata("safir")
+    return metadata("safir")
 
 
 def test_get_project_url(safir_metadata: Message) -> None:


### PR DESCRIPTION
This PR has fixes for two types of mypy checks that came up while developing Safir under current dependencies.

1. mypy reports that `pkg_metadata = cast(Message, metadata(package_name))` is no longer needed in Python 3.10+
2. It seems that starlette's `Request.client` always exists, however, `Request.client.port` can be `None`.

Basically, it seems that these changes are due to improvements in mypy. Are these fixes ok on the basis that adopters of new Safir versions are also adopting the latest mypy and starlette, or would you prefer more defensive changes somehow?