### PR TITLE
Avoid Sphinx 5.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ dev =
     # documentation
     documenteer
     lsst-sphinx-bootstrap-theme
+    sphinx!=5.1.0
     sphinx-automodapi
     sphinx-prompt
 kubernetes =


### PR DESCRIPTION
Sphinx 5.1.0 has an incompatibility with the napoleon extension
that causes the documentation build to break with the error:
"IndexError: pop from an empty deque".

Per https://github.com/sphinx-doc/sphinx/issues/10701 avoid the
5.1.0 version in the hope that the next release will fix this.