### PR TITLE
DM-36156: Drop use of sqlalchemy _IsolationLevel type

### DIFF
--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, overload
+from typing import Optional, overload
 from urllib.parse import quote, urlparse
 
 from sqlalchemy import create_engine
@@ -20,15 +20,6 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.sql.schema import MetaData
 from structlog.stdlib import BoundLogger
-
-# _IsolationLevel is defined in the SQLAlchemy type stubs as a long list of
-# Literal options, which is not type-compatible with str.  Use this hack to
-# use the correct list for type checking, but not for regular execution when
-# the type stubs will not be loaded.
-if TYPE_CHECKING:
-    from sqlalchemy.engine.create import _IsolationLevel
-else:
-    _IsolationLevel = str
 
 __all__ = [
     "DatabaseInitializationError",
@@ -131,7 +122,7 @@ def create_database_engine(
     url: str,
     password: Optional[str],
     *,
-    isolation_level: Optional[_IsolationLevel] = None,
+    isolation_level: Optional[str] = None,
 ) -> AsyncEngine:
     """Create a new async database engine.
 
@@ -231,7 +222,7 @@ def create_sync_session(
     password: Optional[str],
     logger: Optional[BoundLogger] = None,
     *,
-    isolation_level: Optional[_IsolationLevel] = None,
+    isolation_level: Optional[str] = None,
     statement: Optional[Select] = None,
 ) -> scoped_session:
     """Create a new sync database session.

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -1,19 +1,10 @@
 """Manage an async database session."""
 
-from typing import TYPE_CHECKING, AsyncIterator, Optional
+from typing import AsyncIterator, Optional
 
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
 
 from ..database import create_async_session, create_database_engine
-
-# _IsolationLevel is defined in the SQLAlchemy type stubs as a long list of
-# Literal options, which is not type-compatible with str.  Use this hack to
-# use the correct list for type checking, but not for regular execution when
-# the type stubs will not be loaded.
-if TYPE_CHECKING:
-    from sqlalchemy.engine.create import _IsolationLevel
-else:
-    _IsolationLevel = str
 
 __all__ = ["DatabaseSessionDependency", "db_session_dependency"]
 
@@ -77,7 +68,7 @@ class DatabaseSessionDependency:
         url: str,
         password: Optional[str],
         *,
-        isolation_level: Optional[_IsolationLevel] = None,
+        isolation_level: Optional[str] = None,
     ) -> None:
         """Initialize the session dependency.
 


### PR DESCRIPTION
Mypy not longer accepts `sqlalchemy.engine.create._IsolationLevel` as a valid type:

```
src/safir/database.py:131: error: Variable "sqlalchemy.engine.create._IsolationLevel" is not valid as a type src/safir/database.py:131: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
```

This PR simply removes the use of `_IsolationLevel` for type checking and uses the str type throughout instead. I don't know if there's a more sophisticated solution, but this at least unblocks a clean CI.