### PR TITLE
[DM-35879] Support sending Uvicorn logs through structlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
-## 3.3.0 (unreleased)
+## 3.3.0 (2022-09-15)
 
 - Add new function `safir.logging.configure_uvicorn_logging` that routes Uvicorn logging through structlog for consistent formatting.
   It also adds context to Uvicorn logs in the format recognized by Google's Cloud Logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ X.Y.Z (YYYY-MM-DD)
 
 ## 3.3.0 (unreleased)
 
+- Add new function `safir.logging.configure_uvicorn_logging` that routes Uvicorn logging through structlog for consistent formatting.
+  It also adds context to Uvicorn logs in the format recognized by Google's Cloud Logging.
 - Support the newer project metadata structure and URL naming used by `pyproject.toml`-only packages in `safir.metadata.get_metadata`.
 
 ## 3.2.0 (2022-05-13)

--- a/docs/user-guide/logging.rst
+++ b/docs/user-guide/logging.rst
@@ -36,6 +36,25 @@ To configure logging, run the `safir.logging.configure_logging` function in appl
 
    See the `~safir.logging.configure_logging` for details about the parameters.
 
+Including uvicorn logs
+----------------------
+
+Uvicorn_ is normally used to run FastAPI web applications.
+It logs messages about its own operations, and logs each request to the underlying web application.
+By default, those logs use a separate logging profile and do not honor structlog configuration settings such as whether to log messages in JSON.
+
+For consistency, you may want to route Uvicorn log messages through structlog.
+Safir provides the `safir.logging.configure_uvicorn_logging` function to modify the Uvicorn logging configuration to do so:
+
+.. code-block:: python
+
+   configure_uvicorn_logging(config.log_level)
+
+This should be called after `~safir.logging.configure_logging`.
+To ensure that logging is reconfigured before Uvicorn logs its first message, it should be called either during import time of the module that provides the FastAPI application or during execution of a callable that constructs the FastAPI application
+
+When `~safir.logging.configure_uvicorn_logging` is called, it will also add a log processor that parses the Uvicorn access log messages and adds structlog context in the format expected by Google's Cloud Logging system.
+
 .. _logging-in-handlers:
 
 Logging in request handlers


### PR DESCRIPTION
Add a new function, configure_uvicorn_logging, which overrides the Uvicorn logging configuration to use structlog and adds processors to add the log severity and (for access logs) the details of the request as structlog context.  The context is formatted so that, if logged as JSON, the fields match the expectation of Google's Cloud Logging system.

Unfortunately, there doesn't appear to be an easy way to test this function inside Safir's test suite, since Uvicorn is not friendly to being run as a fixture or in the course of a test function.