### PR TITLE
Install graphviz for periodic doc build

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz
+
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:


### PR DESCRIPTION
Graphviz is needed for API docs, so this will resolve the periodic CI failure.