### PR TITLE
DM-37046: Add Profile and LogLevel enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
+## 3.4.0 (unreleased)
+
+- `safir.logging.configure_logging` and `safir.logging.configure_uvicorn_logging` now accept `Profile` and `LogLevel` enums in addition to strings for the `profile` and `log_level` parameters.
+  The new enums are preferred.
+  Support for enums was added in preparation for changing the FastAPI template to use `pydantic.BaseSettings` for its `Configuration` class and validate the values of the `profile` and `log_level` configuration parameters.
+
 ## 3.3.0 (2022-09-15)
 
 - Add new function `safir.logging.configure_uvicorn_logging` that routes Uvicorn logging through structlog for consistent formatting.

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -12,7 +12,7 @@ from unittest.mock import ANY
 import structlog
 
 from safir import logging as safir_logging
-from safir.logging import configure_logging
+from safir.logging import LogLevel, Profile, configure_logging
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -31,7 +31,9 @@ def test_configure_logging_development(caplog: LogCaptureFixture) -> None:
     """Test that development-mode logging is key-value formatted."""
     caplog.set_level(logging.INFO)
 
-    configure_logging(name="myapp", profile="development", log_level="info")
+    configure_logging(
+        name="myapp", profile=Profile.development, log_level=LogLevel.INFO
+    )
     assert safir_logging.logger_name == "myapp"
 
     logger = structlog.get_logger("myapp")
@@ -82,7 +84,9 @@ def test_configure_logging_production(caplog: LogCaptureFixture) -> None:
     """Test that production-mode logging is JSON formatted."""
     caplog.set_level(logging.INFO)
 
-    configure_logging(name="myapp", profile="production", log_level="info")
+    configure_logging(
+        name="myapp", profile=Profile.production, log_level=LogLevel.INFO
+    )
 
     logger = structlog.get_logger("myapp")
     logger = logger.bind(answer=42)
@@ -132,7 +136,7 @@ def test_configure_logging_level(caplog: LogCaptureFixture) -> None:
     """Test that the logging level is set."""
     caplog.set_level(logging.DEBUG)
 
-    configure_logging(name="myapp", log_level="info")
+    configure_logging(name="myapp", log_level=LogLevel.INFO)
     logger = structlog.get_logger("myapp")
 
     logger.info("INFO message")
@@ -157,7 +161,9 @@ def test_duplicate_handlers(capsys: CaptureFixture[str]) -> None:
 
 def test_dev_exception_logging(caplog: LogCaptureFixture) -> None:
     """Test that exceptions are properly logged in the development logger."""
-    configure_logging(name="myapp", profile="development", log_level="info")
+    configure_logging(
+        name="myapp", profile=Profile.development, log_level=LogLevel.INFO
+    )
     logger = structlog.get_logger("myapp")
 
     try:
@@ -173,7 +179,9 @@ def test_dev_exception_logging(caplog: LogCaptureFixture) -> None:
 
 def test_production_exception_logging(caplog: LogCaptureFixture) -> None:
     """Test that exceptions are properly logged in the production logger."""
-    configure_logging(name="myapp", profile="production", log_level="info")
+    configure_logging(
+        name="myapp", profile=Profile.production, log_level=LogLevel.INFO
+    )
     logger = structlog.get_logger("myapp")
 
     try:


### PR DESCRIPTION
Add enums with the acceptable values of Profile and LogLevel for configure_logging and configure_uvicorn_logging.  Modify those functions to accept either strings or enums, for backward compatibility.

This change is in preparation for converting the FastAPI template to use pydantic.BaseSettings instead of a dataclass for its Configuration class.  These enums will be used to validate the profile and log_level settings.

This also changes the name of the argument to configure_uvicorn_logging for consistency with configure_logging. Technically this is a backwards-incompatible change, but the recommended way of calling this function doesn't use a named argument, so hopefully this won't break anything.