### PR TITLE
DM-37051: Drop now-unnecessary types from docs

### DIFF
--- a/src/safir/arq.py
+++ b/src/safir/arq.py
@@ -35,7 +35,7 @@ class ArqJobError(Exception):
 
     Attributes
     ----------
-    job_id : `str`, optional
+    job_id
         The job ID, or `None` if the job ID is not known in this context.
     """
 
@@ -91,17 +91,17 @@ class JobMetadata:
 
     Attributes
     ----------
-    id : str
+    id
         The `arq.jobs.Job` identifier
-    name: str
+    name
         The task name.
-    args: Any
+    args
         The positional arguments to the task function.
-    kwargs: Any
+    kwargs
         The keyword arguments to the task function.
-    enqueue_time: datetime.datetime
+    enqueue_time
         Time when the job was added to the queue.
-    status: str
+    status
         Status of the job.
 
         States are defined by the `arq.jobs.JobStatus` enumeration:
@@ -112,7 +112,7 @@ class JobMetadata:
         - ``in_progress`` (actively being run by a worker)
         - ``complete`` (result is available)
         - ``not_found`` (the job cannot be found)
-    queue_name: str
+    queue_name
         Name of the queue this job belongs to.
     """
 
@@ -183,17 +183,17 @@ class JobResult(JobMetadata):
 
     Attributes
     ----------
-    id : str
+    id
         The `~arq.jobs.Job` identifier
-    name: str
+    name
         The task name.
-    args: Any
+    args
         The positional arguments to the task function.
-    kwargs: Any
+    kwargs
         The keyword arguments to the task function.
-    enqueue_time: datetime.datetime
+    enqueue_time
         Time when the job was added to the queue.
-    status: str
+    status
         Status of the job.
 
         States are defined by the `arq.jobs.JobStatus` enumeration:
@@ -204,14 +204,14 @@ class JobResult(JobMetadata):
         - ``in_progress`` (actively being run by a worker)
         - ``complete`` (result is available)
         - ``not_found`` (the job cannot be found)
-    start_time: datetime.datetime
+    start_time
         Time when the job started.
-    finish_time: datetime.datetime
+    finish_time
         Time when the job finished.
-    success: bool
+    success
         `True` if the job returned without an exception, `False` if an
         exception was raised.
-    result: Any
+    result
         The job's result.
     """
 
@@ -305,11 +305,11 @@ class ArqQueue(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        task_name : `str`
+        task_name
             The function name to run.
         *args
             Positional arguments for the task function.
-        _queue_name : `str`
+        _queue_name
             Name of the queue.
         **kwargs
             Keyword arguments passed to the task function.
@@ -334,15 +334,15 @@ class ArqQueue(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        job_id : `str`
+        job_id
             The job's identifier. This is the same as the `JobMetadata.id`
             attribute, provided when initially adding a job to the queue.
-        queue_name : `str`, optional
+        queue_name
             Name of the queue.
 
         Returns
         -------
-        `JobMetadata`
+        JobMetadata
             Metadata about the queued job.
 
         Raises
@@ -360,15 +360,15 @@ class ArqQueue(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        job_id : `str`
+        job_id
             The job's identifier. This is the same as the `JobMetadata.id`
             attribute, provided when initially adding a job to the queue.
-        queue_name : `str`, optional
+        queue_name
             Name of the queue.
 
         Returns
         -------
-        `JobResult`
+        JobResult
             The job's result, along with metadata about the queued job.
 
         Raises

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -21,6 +21,11 @@ def run_with_asyncio(
     `asyncio.run` when invoked.  The caller must not already be inside an
     asyncio task.
 
+    Parameters
+    ----------
+    f
+        The function to wrap.
+
     Examples
     --------
     An application that uses Safir and `Click`_ may use the following Click

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -43,16 +43,16 @@ def _build_database_url(
 
     Parameters
     ----------
-    url : `str`
+    url
         Database connection URL, not including the password.
-    password : `str` or `None`
+    password
         Database connection password.
-    is_async : `bool`
+    is_async
         Whether the resulting URL should be async or not.
 
     Returns
     -------
-    url : `str`
+    url
         The URL including the password.
 
     Raises
@@ -91,7 +91,19 @@ def datetime_from_db(time: None) -> None:
 
 
 def datetime_from_db(time: Optional[datetime]) -> Optional[datetime]:
-    """Add the UTC time zone to a naive datetime from the database."""
+    """Add the UTC time zone to a naive datetime from the database.
+
+    Parameters
+    ----------
+    time
+        The naive datetime from the database, or `None`
+
+    Returns
+    -------
+    datetime.datetime or None
+        `None` if the input was none, otherwise a timezone-aware version of
+        the same `~datetime.datetime` in the UTC timezone.
+    """
     if not time:
         return None
     if time.tzinfo not in (None, timezone.utc):
@@ -110,7 +122,21 @@ def datetime_to_db(time: None) -> None:
 
 
 def datetime_to_db(time: Optional[datetime]) -> Optional[datetime]:
-    """Strip time zone for storing a datetime in the database."""
+    """Strip time zone for storing a datetime in the database.
+
+    Parameters
+    ----------
+    time
+        The timezone-aware `~datetime.datetime` in the UTC time zone, or
+        `None`.
+
+    Returns
+    -------
+    datetime.datetime or None
+        `None` if the input was `None`, otherwise the same
+        `~datetime.datetime` but timezone-naive and thus suitable for storing
+        in a SQL database.
+    """
     if not time:
         return None
     if time.tzinfo != timezone.utc:
@@ -128,17 +154,17 @@ def create_database_engine(
 
     Parameters
     ----------
-    url : `str`
+    url
         Database connection URL, not including the password.
-    password : `str` or `None`
+    password
         Database connection password.
-    isolation_level : `str`, optional
+    isolation_level
         If specified, sets a non-default isolation level for the database
         engine.
 
     Returns
     -------
-    engine : `sqlalchemy.ext.asyncio.AsyncEngine`
+    sqlalchemy.ext.asyncio.AsyncEngine
         Newly-created database engine.  When done with the engine, the caller
         must call ``await engine.dispose()``.
 
@@ -170,18 +196,18 @@ async def create_async_session(
 
     Parameters
     ----------
-    engine : `sqlalchemy.ext.asyncio.AsyncEngine`
+    engine
         Database engine to use for the session.
-    logger : ``structlog.stdlib.BoundLogger``, optional
+    logger
         Logger for reporting errors.  Used only if a statement is provided.
-    statement : `sqlalchemy.sql.expression.Select`, optional
+    statement
         If provided, statement to run to check database connectivity.  This
         will be modified with ``limit(1)`` before execution.  If not provided,
         database connectivity will not be checked.
 
     Returns
     -------
-    session : `sqlalchemy.ext.asyncio.async_scoped_session`
+    sqlalchemy.ext.asyncio.async_scoped_session
         The database session proxy.  This is an asyncio scoped session that is
         scoped to the current task, which means that it will materialize new
         AsyncSession objects for each asyncio task (and thus each web
@@ -233,23 +259,23 @@ def create_sync_session(
 
     Parameters
     ----------
-    url : `str`
+    url
         Database connection URL, not including the password.
-    password : `str` or `None`
+    password
         Database connection password.
-    logger : ``structlog.stdlib.BoundLogger``, optional
+    logger
         Logger for reporting errors.  Used only if a statement is provided.
-    isolation_level : `str`, optional
+    isolation_level
         If specified, sets a non-default isolation level for the database
         engine.
-    statement : `sqlalchemy.sql.expression.Select`, optional
+    statement
         If provided, statement to run to check database connectivity.  This
         will be modified with ``limit(1)`` before execution.  If not provided,
         database connectivity will not be checked.
 
     Returns
     -------
-    session : `sqlalchemy.orm.scoping.scoped_session`
+    sqlalchemy.orm.scoping.scoped_session
         The database session proxy.  This manages a separate session per
         thread and therefore should be thread-safe.
 
@@ -303,20 +329,19 @@ async def initialize_database(
 
     Parameters
     ----------
-    engine : `sqlalchemy.ext.asyncio.AsyncEngine`
+    engine
         Database engine to use.  Create with `create_database_engine`.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger
         Logger used to report problems
-    schema : `sqlalchemy.sql.schema.MetaData`
+    schema
         Metadata for the database schema.  Generally this will be
         ``Base.metadata`` where ``Base`` is the declarative base used as the
         base class for all ORM table definitions.  The caller must ensure that
         all table definitions have been imported by Python before calling this
         function, or parts of the schema will be missing.
-    reset : `bool`, optional
+    reset
         If set to `True`, drop all tables and reprovision the database.
-        Useful when running tests with an external database.  Default is
-        `False`.
+        Useful when running tests with an external database.
 
     Raises
     ------

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -96,7 +96,7 @@ def datetime_from_db(time: Optional[datetime]) -> Optional[datetime]:
     Parameters
     ----------
     time
-        The naive datetime from the database, or `None`
+        The naive datetime from the database, or `None`.
 
     Returns
     -------

--- a/src/safir/dependencies/arq.py
+++ b/src/safir/dependencies/arq.py
@@ -28,7 +28,7 @@ class ArqDependency:
 
         Parameters
         ----------
-        mode : `safir.arq.ArqMode`
+        mode
             The mode to operate the queue dependency in. With
             `safir.arq.ArqMode.production`, this method initializes a
             Redis-based arq queue and the dependency creates a
@@ -37,7 +37,7 @@ class ArqDependency:
             With `safir.arq.ArqMode.test`, this method instead initializes an
             in-memory mocked version of arq that you use with the
             `safir.arq.MockArqQueue` client.
-        redis_settings : `arq.connections.RedisSettings`
+        redis_settings
             The arq Redis settings, required when the ``mode`` is
             `safir.arq.ArqMode.production`. See arq's
             `~arq.connections.RedisSettings` documentation for details on

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -45,7 +45,7 @@ class DatabaseSessionDependency:
 
         Returns
         -------
-        session : `sqlalchemy.ext.asyncio.AsyncSession`
+        sqlalchemy.ext.asyncio.AsyncSession
             The newly-created session.
         """
         assert self._session, "db_session_dependency not initialized"
@@ -74,11 +74,11 @@ class DatabaseSessionDependency:
 
         Parameters
         ----------
-        url : `str`
+        url
             Database connection URL, not including the password.
-        password : `str` or `None`
+        password
             Database connection password.
-        isolation_level : `str`, optional
+        isolation_level
             If specified, sets a non-default isolation level for the database
             engine.
         """
@@ -100,7 +100,7 @@ class DatabaseSessionDependency:
 
         Parameters
         ----------
-        engine : `sqlalchemy.ext.asyncio.AsyncEngine`
+        engine
             Database engine to use for all sessions.
         """
         self._override_engine = engine

--- a/src/safir/dependencies/logger.py
+++ b/src/safir/dependencies/logger.py
@@ -40,7 +40,7 @@ class LoggerDependency:
 
         Returns
         -------
-        logger : `structlog.stdlib.BoundLogger`
+        structlog.stdlib.BoundLogger
             The bound logger.
         """
         if not self.logger:

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -81,8 +81,8 @@ def add_log_severity(
 
     Returns
     -------
-    `structlog.types.EventDict`
-        The modified `~structlog.types.EventDict` with the added key.
+    ``structlog.types.EventDict``
+        The modified ``structlog.types.EventDict`` with the added key.
     """
     severity = add_log_level(logger, method_name, {})["level"]
     event_dict["severity"] = severity

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -70,18 +70,18 @@ def add_log_severity(
 
     Parameters
     ----------
-    logger : `logging.Logger`
+    logger
         The wrapped logger object.
-    method_name : `str`
+    method_name
         The name of the wrapped method (``warning`` or ``error``, for
         example).
-    event_dict : `structlog.types.EventDict`
+    event_dict
         Current context and current event. This parameter is also modified in
         place, matching the normal behavior of structlog processors.
 
     Returns
     -------
-    event_dict : `structlog.types.EventDict`
+    `structlog.types.EventDict`
         The modified `~structlog.types.EventDict` with the added key.
     """
     severity = add_log_level(logger, method_name, {})["level"]
@@ -100,10 +100,10 @@ def configure_logging(
 
     Parameters
     ----------
-    name : `str`
+    name
         Name of the logger, which is typically the name of your application's
         root namespace.
-    profile : `Profile`, optional
+    profile
         The name of the application profile:
 
         development
@@ -111,14 +111,12 @@ def configure_logging(
         production
             Log messages are formatted as JSON objects.
 
-        May be given as a `Profile` enum value (preferred) or a string. The
-        default is ``Profile.production``.
-    log_level : `LogLevel`, optional
+        May be given as a `Profile` enum value (preferred) or a string.
+    log_level
         The Python log level. May be given as a `LogLevel` enum (preferred)
-        or a case-insensitive string. The default is ``LogLevel.INFO``.
-    add_timestamp : `bool`
-        Whether to add an ISO-format timestamp to each log message.  The
-        default is `False`.
+        or a case-insensitive string.
+    add_timestamp
+        Whether to add an ISO-format timestamp to each log message.
 
     Notes
     -----
@@ -219,18 +217,18 @@ def _process_uvicorn_access_log(
 
     Parameters
     ----------
-    logger : `logging.Logger`
+    logger
         The wrapped logger object.
-    method_name : `str`
+    method_name
         The name of the wrapped method (``warning`` or ``error``, for
         example).
-    event_dict : `structlog.types.EventDict`
+    event_dict
         Current context and current event. This parameter is also modified in
         place, matching the normal behavior of structlog processors.
 
     Returns
     -------
-    event_dict : `structlog.types.EventDict`
+    EventDict
         The modified `~structlog.types.EventDict` with the added key.
     """
     match = _UVICORN_ACCESS_REGEX.match(event_dict["event"])
@@ -260,9 +258,9 @@ def configure_uvicorn_logging(
 
     Parameters
     ----------
-    log_level : `LogLevel`, optional
+    log_level
         The Python log level. May be given as a `LogLevel` enum (preferred)
-        or a case-insensitive string. The default is ``LogLevel.INFO``.
+        or a case-insensitive string.
 
     Notes
     -----

--- a/src/safir/metadata.py
+++ b/src/safir/metadata.py
@@ -38,16 +38,16 @@ def get_metadata(*, package_name: str, application_name: str) -> Metadata:
 
     Parameters
     ----------
-    pacakge_name : `str`
+    pacakge_name
         The name of the package (Python namespace). This name is used to look
         up metadata about the package.
-    application_name : `str`
+    application_name
         The value to return as the application name (the ``name`` metadata
         field).
 
     Returns
     -------
-    metadata : `Metadata`
+    Metadata
         The package metadata as a Pydantic model, suitable for returning as
         the result of a FastAPI route.
 
@@ -108,10 +108,10 @@ def get_project_url(meta: Message, label: str) -> Optional[str]:
 
     Parameters
     ----------
-    meta : `email.message.Message`
+    meta
         The package metadata, as returned by the
         ``importlib.metadata.metadata`` function.
-    label : `str`
+    label
         The URL's label. Consider the follow snippet of a ``pyproject.toml``
         file:
 
@@ -139,7 +139,7 @@ def get_project_url(meta: Message, label: str) -> Optional[str]:
 
     Returns
     -------
-    url : `str` or `None`
+    str or None
         The URL. If the label is not found, the function returns `None`.
 
     Examples

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -31,7 +31,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
     Parameters
     ----------
-    proxies : List[`ipaddress._BaseNetwork`], optional
+    proxies
         The networks of the trusted proxies.  If not specified, defaults to
         the empty list, which means only the immediately upstream proxy will
         be trusted.
@@ -55,14 +55,14 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         Parameters
         ----------
-        request : ``fastapi.Request``
+        request
             The incoming request.
-        call_next : `typing.Callable`
+        call_next
             The next step in the processing stack.
 
         Returns
         -------
-        response : ``fastapi.Response``
+        ``fastapi.Response``
             The response with additional information about proxy headers.
         """
         forwarded_for = list(reversed(self._get_forwarded_for(request)))
@@ -113,12 +113,12 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         Parameters
         ----------
-        request : ``fastapi.Request``
+        request
             The incoming request.
 
         Returns
         -------
-        forwarded_for : List[``ipaddress._BaseAddress``]
+        list of ipaddress._BaseAddress
             The list of addresses found in the header.  If there are multiple
             ``X-Forwarded-For`` headers, we don't know which one is correct,
             so act as if there are no headers.
@@ -137,12 +137,12 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         Parameters
         ----------
-        request : ``fastapi.Request``
+        request
             The incoming request.
 
         Returns
         -------
-        forwarded_host : `str`
+        str
             The value of the ``X-Forwarded-Host`` header, if present and if
             there is only one header.  If there are multiple
             ``X-Forwarded-Host`` headers, we don't know which one is correct,
@@ -158,12 +158,12 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         Parameters
         ----------
-        request : ``fastapi.Request``
+        request
             The incoming request.
 
         Returns
         -------
-        forwarded_proto : List[`str`]
+        list of str
             The list of schemes found in the header.  If there are multiple
             ``X-Forwarded-Proto`` headers, we don't know which one is correct,
             so act as if there are no headers.

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -57,13 +57,13 @@ class MockKubernetesApi:
 
         Parameters
         ----------
-        kind : `str`
+        kind
             The Kubernetes kind, such as ``Secret`` or ``Pod``.  This is
             case-sensitive.
 
         Returns
         -------
-        objects : List[`typing.Any`]
+        list of Any
             All objects of that kind found in the mock, sorted by namespace
             and then name.
         """
@@ -310,7 +310,7 @@ def patch_kubernetes() -> Iterator[MockKubernetesApi]:
 
     Returns
     -------
-    mock_kubernetes : `MockKubernetesApi`
+    MockKubernetesApi
         The mock Kubernetes API object.
 
     Notes


### PR DESCRIPTION
The current documenteer setup correctly resolves types and doesn't require reiterating them in docstrings in most cases.  Drop them where possible.  Add better docstrings to datetime_from_db and datetime_to_db.

For reasons that I don't understand, structlog.types.EventDict doesn't resolve unquoted but does work in backticks, so add backticks to keep Sphinx happy.