### PR TITLE
Generate API docs for safir.asyncio

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,9 @@ API reference
 .. automodapi:: safir.arq
    :include-all-objects:
 
+.. automodapi:: safir.asyncio
+   :include-all-objects:
+
 .. automodapi:: safir.database
 
 .. automodapi:: safir.dependencies.arq


### PR DESCRIPTION
This adds safir.asyncio to the API reference.