### PR TITLE
DM-37291: Add CamelCaseModel helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ X.Y.Z (YYYY-MM-DD)
 
 ## 3.5.0 (unreleased)
 
-- Add new helper class `safir.pydantic.CamelCaseModel`, which is identical to `pydantic.BaseModel` except with configuration added to accept camel-case keys using the `safir.pydantic.to_camel_case` alias generator.
+- Add new helper class `safir.pydantic.CamelCaseModel`, which is identical to `pydantic.BaseModel` except with configuration added to accept camel-case keys using the `safir.pydantic.to_camel_case` alias generator and overrides of `dict` and `json` to export in camel-case by default.
 
 ## 3.4.0 (2022-11-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
+## 3.5.0 (unreleased)
+
+- Add new helper class `safir.pydantic.CamelCaseModel`, which is identical to `pydantic.BaseModel` except with configuration added to accept camel-case keys using the `safir.pydantic.to_camel_case` alias generator.
+
 ## 3.4.0 (2022-11-29)
 
 - `safir.logging.configure_logging` and `safir.logging.configure_uvicorn_logging` now accept `Profile` and `LogLevel` enums in addition to strings for the `profile` and `log_level` parameters.

--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -52,10 +52,11 @@ To use it, add a configuration block to any Pydantic model that has snake-case a
            allow_population_by_field_name = True
 
 By default, only the generated aliases (so, in this case, only the camel-case form of the attribute, ``someField``) are supported.
-The additional setting ``allow_population_by_field_name``, tells Pydantic to allow either ``some_field`` or ``soemField`` in the input.
+The additional setting ``allow_population_by_field_name``, tells Pydantic to allow either ``some_field`` or ``someField`` in the input.
 
 As a convenience, you can instead inherit from `~safir.pydantic.CamelCaseModel`, which is a derived class of `~pydantic.BaseModel` with those settings added.
 This is somewhat less obvious when reading the classes and thus less self-documenting, but is less tedious if you have numerous models that need to support camel-case.
+`~safir.pydantic.CamelCaseModel` also overrides ``dict`` and ``json`` to change the default of ``by_alias`` to `True` so that this model exports in camel-case by default.
 
 Requiring exactly one of a list of attributes
 =============================================

--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -54,8 +54,8 @@ To use it, add a configuration block to any Pydantic model that has snake-case a
 By default, only the generated aliases (so, in this case, only the camel-case form of the attribute, ``someField``) are supported.
 The additional setting ``allow_population_by_field_name``, tells Pydantic to allow either ``some_field`` or ``soemField`` in the input.
 
-Adding this configuration can be tedious if you have a lot of models.
-In that case, consider making a subclass of `~pydantic.BaseModel` with this ``Config`` subclass, and having all of your models that need to support camel-case inherit from that class.
+As a convenience, you can instead inherit from `~safir.pydantic.CamelCaseModel`, which is a derived class of `~pydantic.BaseModel` with those settings added.
+This is somewhat less obvious when reading the classes and thus less self-documenting, but is less tedious if you have numerous models that need to support camel-case.
 
 Requiring exactly one of a list of attributes
 =============================================

--- a/src/safir/pydantic.py
+++ b/src/safir/pydantic.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Union
 
+from pydantic import BaseModel
+
 __all__ = [
+    "CamelCaseModel",
     "normalize_datetime",
     "to_camel_case",
     "validate_exactly_one_of",
@@ -92,13 +95,25 @@ def to_camel_case(string: str) -> str:
                allow_population_by_field_name = True
 
     This must be added to every class that uses ``snake_case`` for an
-    attribute and that needs to be initialized from ``camelCase``. If there
-    are a lot of those classes, consider making a derivative class of
-    `~pydantic.BaseModel` that sets these configuration options, and having
-    all of your model classes inherit from it.
+    attribute and that needs to be initialized from ``camelCase``.
+    Alternately, inherit from `~safir.pydantic.CamelCaseModel`, which is
+    derived from `pydantic.BaseModel` with those settings added.
     """
     components = string.split("_")
     return components[0] + "".join(c.title() for c in components[1:])
+
+
+class CamelCaseModel(BaseModel):
+    """`pydantic.BaseModel` configured to accept camel-case input.
+
+    This is a convenience class identical to `~pydantic.BaseModel` except with
+    an alias generator configured so that it can be initialized with either
+    camel-case or snake-case keys. See `to_camel_case` for more details.
+    """
+
+    class Config:
+        alias_generator = to_camel_case
+        allow_population_by_field_name = True
 
 
 def validate_exactly_one_of(

--- a/tests/pydantic_test.py
+++ b/tests/pydantic_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -44,19 +45,31 @@ def test_camel_case_model() -> None:
         replace_403: bool
         foo_bar_baz: str
 
-    data = TestModel.parse_obj(
-        {"minimumLifetime": 10, "replace403": False, "fooBarBaz": "something"}
-    )
+    camel = {
+        "minimumLifetime": 10,
+        "replace403": False,
+        "fooBarBaz": "something",
+    }
+    snake = {
+        "minimum_lifetime": 10,
+        "replace_403": False,
+        "foo_bar_baz": "something",
+    }
+    data = TestModel.parse_obj(camel)
     assert data.minimum_lifetime == 10
     assert not data.replace_403
     assert data.foo_bar_baz == "something"
+    assert data.dict() == camel
+    assert data.dict(by_alias=False) == snake
+    assert data.json() == json.dumps(camel)
+    assert data.json(by_alias=False) == json.dumps(snake)
 
-    data = TestModel.parse_obj(
-        {"minimum_lifetime": 20, "replace_403": True, "foo_bar_baz": "else"}
-    )
-    assert data.minimum_lifetime == 20
-    assert data.replace_403
-    assert data.foo_bar_baz == "else"
+    snake_data = TestModel.parse_obj(snake)
+    assert data.minimum_lifetime == 10
+    assert not data.replace_403
+    assert data.foo_bar_baz == "something"
+    assert snake_data.dict() == data.dict()
+    assert snake_data.json() == data.json()
 
 
 def test_validate_exactly_one_of() -> None:

--- a/tests/pydantic_test.py
+++ b/tests/pydantic_test.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from safir.pydantic import (
+    CamelCaseModel,
     normalize_datetime,
     to_camel_case,
     validate_exactly_one_of,
@@ -35,6 +36,27 @@ def test_to_camel_case() -> None:
     assert to_camel_case("minimum_lifetime") == "minimumLifetime"
     assert to_camel_case("replace_403") == "replace403"
     assert to_camel_case("foo_bar_baz") == "fooBarBaz"
+
+
+def test_camel_case_model() -> None:
+    class TestModel(CamelCaseModel):
+        minimum_lifetime: int
+        replace_403: bool
+        foo_bar_baz: str
+
+    data = TestModel.parse_obj(
+        {"minimumLifetime": 10, "replace403": False, "fooBarBaz": "something"}
+    )
+    assert data.minimum_lifetime == 10
+    assert not data.replace_403
+    assert data.foo_bar_baz == "something"
+
+    data = TestModel.parse_obj(
+        {"minimum_lifetime": 20, "replace_403": True, "foo_bar_baz": "else"}
+    )
+    assert data.minimum_lifetime == 20
+    assert data.replace_403
+    assert data.foo_bar_baz == "else"
 
 
 def test_validate_exactly_one_of() -> None:


### PR DESCRIPTION
Add new helper class safir.pydantic.CamelCaseModel, which is identical to pydantic.BaseModel except with configuration added to accept camel-case keys using the safir.pydantic.to_camel_case alias generator.  This is a bit less self-documenting, but is less tedious if there are a lot of classes that need this configuration (such as a complex Kubernetes custom object model).