### PR TITLE
DM-37589: Add ErrorLocation enum to models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
+## 3.6.0 (unreleased)
+
+- Add a `safir.models.ErrorLocation` enum holding valid values for the first element of the `loc` array in `safir.models.ErrorModel`.
+  Due to limitations in Python typing, `loc` is not type-checked against this enum, but it may be useful to applications constructing FastAPI-compatible error messages.
+
 ## 3.5.0 (2023-01-12)
 
 - Add new helper class `safir.gcs.SignedURLService` to generate signed URLs to Google Cloud Storage objects using workload identity.

--- a/docs/user-guide/fastapi-errors.rst
+++ b/docs/user-guide/fastapi-errors.rst
@@ -1,0 +1,67 @@
+#################################
+Handling HTTP errors with FastAPI
+#################################
+
+FastAPI automatically returns some HTTP errors for the application, such as 422 errors when the input to a handler doesn't match its requirements.
+Other errors are normally returned by raising ``fastapi.HTTPException`` with an appropriate ``status_code`` parameter.
+
+Errors raised by FastAPI will have a JSON body that follows a standard syntax.
+To provide standard error reporting for all application APIs, you may wish to return other errors using the same structure.
+
+Raising structured errors
+=========================
+
+``fastapi.HTTPException`` supports a ``detail`` parameter that should include information about the cause of the error.
+FastAPI accepts an arbitrary JSON-serializable data in that parameter, but for compatibility with the errors generated internally by FastAPI, the value should be an array of dict representations of `safir.models.ErrorDetail`.
+
+The ``loc`` attribute of `~safir.models.ErrorDetail`, if present, is an ordered list of location keys identifing the specific input data that caused the error.
+The first element of ``loc`` should be chosen from the values of `safir.models.ErrorLocation`.
+
+For example, for an error in the ``job_id`` path variable, the value of ``loc`` would be ``[ErrorLocation.path, "job_id"]``.
+For an error in a nested ``account`` element in the body, the value of ``loc`` might be ``[ErrorLocation.body, "config", "account"]``.
+``loc`` may be omitted for errors not caused by a specific element of input data.
+
+The code to raise ``fastapi.HTTPException`` should therefore look something like this:
+
+.. code-block:: python
+
+   raise HTTPException(
+       status_code=status.HTTP_404_NOT_FOUND,
+       detail=[
+           {
+               "loc": [ErrorLocation.path, "foo"],
+               "msg": msg,
+               "type": "invalid_foo",
+           },
+       ],
+   )
+
+
+Declaring the error model
+=========================
+
+To declare that a particular error code returns `safir.models.ErrorModel`, use the ``responses`` attribute to either the route decorator or to ``include_router`` if it applies to all routes provided by a router.
+
+For example, for a single route:
+
+.. code-block:: python
+
+   @router.get(
+       "/route/{foo}",
+       ...,
+       responses={404: {"description": "Not found", "model": ErrorModel}},
+   )
+   async def route(foo: str) -> None:
+       ...
+
+If all routes provided by a router have the same error handling behavior for a given response code, it saves some effort to instead do this when including the router, normally in ``main.py``:
+
+.. code-block:: python
+
+   app.include_router(
+       api.router,
+       prefix="/auth/api/v1",
+       responses={
+           403: {"description": "Permission denied", "model": ErrorModel},
+       },
+   )

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -24,3 +24,4 @@ User guide
    kubernetes
    pydantic
    gcs
+   fastapi-errors

--- a/src/safir/models.py
+++ b/src/safir/models.py
@@ -17,7 +17,11 @@ similar to this:
        raise HTTPException(
            status_code=status.HTTP_404_NOT_FOUND,
            detail=[
-               {"loc": ["path", "foo"], "msg": msg, "type": "invalid_foo"},
+               {
+                   "loc": [ErrorLocation.path, "foo"],
+                   "msg": msg,
+                   "type": "invalid_foo",
+               },
            ],
        )
 
@@ -31,11 +35,29 @@ generate good documentation.
 # Examples and notes kept in the module docstring because they're not
 # appropriate for the API documentation generated for a service.
 
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
-__all__ = ["ErrorDetail", "ErrorModel"]
+__all__ = [
+    "ErrorDetail",
+    "ErrorLocation",
+    "ErrorModel",
+]
+
+
+class ErrorLocation(str, Enum):
+    """Possible locations for an error.
+
+    The first element of ``loc`` in `ErrorDetail` should be chosen from one of
+    these values.
+    """
+
+    body = "body"
+    header = "header"
+    path = "path"
+    query = "query"
 
 
 class ErrorDetail(BaseModel):

--- a/src/safir/models.py
+++ b/src/safir/models.py
@@ -1,39 +1,11 @@
 """Standard models for FastAPI applications.
 
-Examples
---------
-To reference the `ErrorModel` model when returning an error message, use code
-similar to this:
-
-.. code-block:: python
-
-   @router.get(
-       "/route/{foo}",
-       ...,
-       responses={404: {"description": "Not found", "model": ErrorModel}},
-   )
-   async def route(foo: str) -> None:
-       ...
-       raise HTTPException(
-           status_code=status.HTTP_404_NOT_FOUND,
-           detail=[
-               {
-                   "loc": [ErrorLocation.path, "foo"],
-                   "msg": msg,
-                   "type": "invalid_foo",
-               },
-           ],
-       )
-
 Notes
 -----
 FastAPI does not appear to export its error response model in a usable form,
 so define a copy of it so that we can reference it in API definitions to
 generate good documentation.
 """
-
-# Examples and notes kept in the module docstring because they're not
-# appropriate for the API documentation generated for a service.
 
 from enum import Enum
 from typing import List, Optional


### PR DESCRIPTION
Add an enum representing the valid first members of the loc array in the ErrorDetail model.  Due to the array (and backward compatibility) the typing can't be enforced, but it's still of use to applications that use Safir and construct custom errors.