### PR TITLE
DM-37589: Add datetime utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ X.Y.Z (YYYY-MM-DD)
 
 - Add a `safir.models.ErrorLocation` enum holding valid values for the first element of the `loc` array in `safir.models.ErrorModel`.
   Due to limitations in Python typing, `loc` is not type-checked against this enum, but it may be useful to applications constructing FastAPI-compatible error messages.
+- Add `safir.datetime.current_datetime` to get a normalized `datetime` object representing the current date and time.
+- Add `safir.datetime.isodatetime` and `safir.datetime.parse_isodatetime` to convert to and from the most useful form of ISO 8601 dates, used by both Kubernetes and the IVOA UWS standard.
+  Also add `safir.pydantic.normalize_isodatetime` to accept only that same format as input to a Pydantic model with a `datetime` field.
 
 ## 3.5.0 (2023-01-12)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,8 @@ API reference
 
 .. automodapi:: safir.database
 
+.. automodapi:: safir.datetime
+
 .. automodapi:: safir.dependencies.arq
    :include-all-objects:
 

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -177,6 +177,8 @@ This will open a transaction, commit the transaction at the end of the block, an
    Due to an as-yet-unexplained interaction with FastAPI 0.74 and later, managing the transaction inside the database session dependency does not work.
    Calling ``await session.commit()`` there, either explicitly or implicitly via a context manager, immediately fails by raising ``asyncio.CancelledError`` and the transaction is not committed or closed.
 
+.. _database-datetime:
+
 Handling datetimes in database tables
 =====================================
 

--- a/docs/user-guide/datetime.rst
+++ b/docs/user-guide/datetime.rst
@@ -1,0 +1,66 @@
+#################
+datetime handling
+#################
+
+There are an unfortunately large number of ways to represent dates and times in Python and in serialization formats.
+Unless they're used consistently, conflicting expectations may lead to bugs.
+Applications using Safir may wish to follow these rules:
+
+- All internal representations of dates and times should be converted to `~datetime.datetime` objects as early as possible, and converted back to other formats as late as possible.
+  All internal APIs should expect `~datetime.datetime` objects.
+
+- All `~datetime.datetime` objects used internally by the application should be time zone aware and in the UTC time zone.
+
+- All time intervals should be converted to `~datetime.timedelta` objects as early as possible, and all internal APIs should expect `~datetime.timedelta` objects.
+  The one exception is when the time interval is a constant used as a validation parameter in contexts (such as some Pydantic and FastAPI cases) where a `~datetime.timedelta` is not supported.
+
+Safir provides several small utility functions for `~datetime.datetime` handling to help ensure consistency with these rules.
+Also see the Pydantic validation functions at :ref:`pydantic-datetime` and the utility functions for handling `~datetime.datetime` objects in database schemas in :ref:`database-datetime`.
+
+Getting the current date and time
+=================================
+
+To get the current date and time as a `~datetime.datetime` object, use `safir.datetime.current_datetime`.
+
+In addition to ensuring that the returned object is time zone aware and uses the UTC time zone, this function sets milliseconds to zero.
+This is useful for database-based applications, since databases may or may not store milliseconds or, worse, accept non-zero milliseconds and then silently discard them.
+Mixing `~datetime.datetime` objects with and without milliseconds can lead to confusing bugs, which using this function consistently can avoid.
+
+If milliseconds are needed for a particular application, this helper function is not suitable.
+
+Date and time serialization
+===========================
+
+There are two reasonable serialization formats for dates and times: seconds since epoch, and ISO 8601.
+Both are also supported by Pydantic.
+
+Seconds since epoch has the advantage of extreme simplicity and clarity, since by UNIX convention seconds since epoch is always in UTC and easy to both generate and parse.
+However, it's not very friendly to humans, who usually can't convert seconds since epoch into a human-meaningful date or time in their head.
+
+ISO 8601 is a large and complex standard that supports numerous partial date or time representations, time zone information, week numbers, and time intervals.
+However, its most basic date and time format, ``YYYY-MM-DDTHH:MM:SSZ`` (where the ``T`` and ``Z`` are fixed letters and the other letters represent their normal date and time components), provides a good balance of unambiguous parsing and human readability.
+The trailing ``Z`` indicates UTC.
+
+This subset of ISO 8601 is used by both Kubernetes and the IVOA UWS standard.
+
+Safir provides two utility functions for this date and time serialization format.
+`safir.datetime.isodatetime` converts a `~datetime.datetime` to this format.
+`safir.datetime.parse_isodatetime` goes the opposite direction, converting this format to a time zone aware `~datetime.datetime` in UTC.
+
+To use this format as the serialized representation of any `~datetime.datetime` objects in a Pydantic model, use the following Pydantic configuration:
+
+.. code-block:: python
+
+   from datetime import datetime
+
+   from pydantic import BaseModel
+   from safir.datetime import isodatetime
+
+
+   class Example(BaseModel):
+       some_time: datetime
+
+       class Config:
+           json_encoders = {datetime: lambda v: isodatetime(v)}
+
+Also see the Pydantic validation function `safir.pydantic.normalize_isodatetime`, discussed further at :ref:`pydantic-datetime`.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -25,3 +25,4 @@ User guide
    pydantic
    gcs
    fastapi-errors
+   datetime

--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -5,6 +5,8 @@ Utilities for Pydantic models
 Several validation and configuration problems arise frequently with Pydantic models.
 Safir offers some utility functions to assist in solving them.
 
+.. _pydantic-datetime:
+
 Normalizing datetime fields
 ===========================
 
@@ -31,6 +33,16 @@ Here's an example of how to use it:
        )(normalize_datetime)
 
 Multiple attributes can be listed as the initial arguments of `~pydantic.validator` if there are multiple fields that need to be checked.
+
+This validator accepts all of the input formats that Pydantic accepts.
+This includes some ambiguous formats, such as an ISO 8601 date without time zone information.
+All such dates are given a consistent interpretation as UTC, but the results may be surprising if the caller expected local time.
+In some cases, it may be desirable to restrict input to one unambiguous format.
+
+This can be done by using `~safir.pydantic.normalize_isodatetime` as the validator instead.
+This function only accepts ``YYYY-MM-DDTHH:MM[:SS]Z`` as the input format.
+The ``Z`` time zone prefix indicating UTC is mandatory.
+It is called the same way as `~safir.pydantic.normalize_datetime`.
 
 Accepting camel-case attributes
 ===============================

--- a/src/safir/datetime.py
+++ b/src/safir/datetime.py
@@ -1,0 +1,85 @@
+"""Date and time manipulation utility functions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+__all__ = [
+    "current_datetime",
+    "isodatetime",
+    "parse_isodatetime",
+]
+
+
+def current_datetime() -> datetime:
+    """Construct a `~datetime.datetime` for the current time.
+
+    Databases do not always store microseconds in time fields, and having some
+    dates with microseconds and others without them can lead to bugs.  It's
+    also easy to forget to force all `~datetime.datetime` objects to be time
+    zone aware.  This function avoids both problems by forcing UTC and forcing
+    microseconds to 0.
+
+    Returns
+    -------
+    datetime.datetime
+        The current time forced to UTC and with the microseconds field zeroed.
+    """
+    return datetime.now(tz=timezone.utc).replace(microsecond=0)
+
+
+def isodatetime(timestamp: datetime) -> str:
+    """Format a timestamp in UTC in a standard ISO date format.
+
+    Parameters
+    ----------
+    timestamp
+        Date and time to format.
+
+    Returns
+    -------
+    str
+        Date and time formatted as an ISO 8601 date and time using ``Z`` as
+        the time zone.  This format is compatible with both Kubernetes and the
+        IVOA UWS standard.
+
+    Raises
+    ------
+    ValueError
+        The provided timestamp was not in UTC.
+    """
+    if timestamp.tzinfo not in (None, timezone.utc):
+        raise ValueError("Datetime {timestamp} not in UTC")
+    return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_isodatetime(time_string: str) -> Optional[datetime]:
+    """Parse a string in a standard ISO date format.
+
+    Parameters
+    ----------
+    time_string
+        Date and time formatted as an ISO 8601 date and time using ``Z`` as
+        the time zone.  This is the same format produced by `isodatetime` and
+        is compatible with Kubernetes and the IVOA UWS standard.
+
+    Returns
+    -------
+    datetime.datetime
+        The corresponding `datetime.datetime`.
+
+    Raises
+    ------
+    ValueError
+        The provided ``time_string`` is not in the correct format.
+
+    Notes
+    -----
+    When parsing input for a model, use `safir.pydantic.normalize_isodatetime`
+    instead of this function.  Using a model will be the normal case; this
+    function is primarily useful in tests.
+    """
+    if not time_string.endswith("Z"):
+        raise ValueError(f"{time_string} does not end with Z")
+    return datetime.fromisoformat(time_string[:-1] + "+00:00")

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,0 +1,35 @@
+"""Tests for datetime utility functions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from safir.datetime import current_datetime, isodatetime, parse_isodatetime
+
+
+def test_current_datetime() -> None:
+    time = current_datetime()
+    assert time.microsecond == 0
+    assert time.tzinfo == timezone.utc
+    now = datetime.now(tz=timezone.utc)
+    assert now - timedelta(seconds=2) <= time <= now
+
+
+def test_isodatetime() -> None:
+    time = datetime.fromisoformat("2022-09-16T12:03:45+00:00")
+    assert isodatetime(time) == "2022-09-16T12:03:45Z"
+
+    with pytest.raises(ValueError):
+        isodatetime(datetime.fromisoformat("2022-09-16T12:03:45+02:00"))
+
+
+def test_parse_isodatetime() -> None:
+    time = parse_isodatetime("2022-09-16T12:03:45Z")
+    assert time == datetime(2022, 9, 16, 12, 3, 45, tzinfo=timezone.utc)
+    now = current_datetime()
+    assert parse_isodatetime(isodatetime(now)) == now
+
+    with pytest.raises(ValueError):
+        parse_isodatetime("2022-09-16T12:03:45+00:00")

--- a/tests/pydantic_test.py
+++ b/tests/pydantic_test.py
@@ -10,6 +10,7 @@ import pytest
 from safir.pydantic import (
     CamelCaseModel,
     normalize_datetime,
+    normalize_isodatetime,
     to_camel_case,
     validate_exactly_one_of,
 )
@@ -30,6 +31,25 @@ def test_normalize_datetime() -> None:
     aware_date = normalize_datetime(naive_date)
     assert aware_date == naive_date.replace(tzinfo=timezone.utc)
     assert aware_date.tzinfo == timezone.utc
+
+
+def test_normalize_isodatetime() -> None:
+    assert normalize_isodatetime(None) is None
+
+    date = datetime.fromisoformat("2023-01-25T15:44:34+00:00")
+    assert date == normalize_isodatetime("2023-01-25T15:44:34Z")
+
+    date = datetime.fromisoformat("2023-01-25T15:44:00+00:00")
+    assert date == normalize_isodatetime("2023-01-25T15:44Z")
+
+    with pytest.raises(ValueError):
+        normalize_isodatetime("2023-01-25T15:44:00+00:00")
+
+    with pytest.raises(ValueError):
+        normalize_isodatetime(1668814932)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError):
+        normalize_isodatetime("next thursday")
 
 
 def test_to_camel_case() -> None:


### PR DESCRIPTION
These are fairly small, but I find myself copying and pasting them between projects anyway.  current_datetime provides a normalized datetime for the current time.  isodatetime and parse_isodatetime handle the most useful version of ISO 8601 date representation. normalize_isodatetime does the same for input to Pydantic models in cases where accepting all the variations that Pydantic accepts isn't desirable.