### PR TITLE
DM-37760: Change the change log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,118 +7,142 @@ X.Y.Z (YYYY-MM-DD)
 
 ## 3.6.0 (unreleased)
 
-- Add a `safir.models.ErrorLocation` enum holding valid values for the first element of the `loc` array in `safir.models.ErrorModel`.
-  Due to limitations in Python typing, `loc` is not type-checked against this enum, but it may be useful to applications constructing FastAPI-compatible error messages.
+### New features
+
+- Add a `safir.models.ErrorLocation` enum holding valid values for the first element of the `loc` array in `safir.models.ErrorModel`. Due to limitations in Python typing, `loc` is not type-checked against this enum, but it may be useful to applications constructing FastAPI-compatible error messages.
 - Add `safir.datetime.current_datetime` to get a normalized `datetime` object representing the current date and time.
-- Add `safir.datetime.isodatetime` and `safir.datetime.parse_isodatetime` to convert to and from the most useful form of ISO 8601 dates, used by both Kubernetes and the IVOA UWS standard.
-  Also add `safir.pydantic.normalize_isodatetime` to accept only that same format as input to a Pydantic model with a `datetime` field.
+- Add `safir.datetime.isodatetime` and `safir.datetime.parse_isodatetime` to convert to and from the most useful form of ISO 8601 dates, used by both Kubernetes and the IVOA UWS standard. Also add `safir.pydantic.normalize_isodatetime` to accept only that same format as input to a Pydantic model with a `datetime` field.
 
 ## 3.5.0 (2023-01-12)
 
-- Add new helper class `safir.gcs.SignedURLService` to generate signed URLs to Google Cloud Storage objects using workload identity.
-  To use this class, depend on `safir[gcs]`.
-- Add the `safir.testing.gcs` module, which can be used to mock the Google Cloud Storage API for testing.
-  To use this module, depend on `safir[gcs]`.
+### New features
+
+- Add new helper class `safir.gcs.SignedURLService` to generate signed URLs to Google Cloud Storage objects using workload identity. To use this class, depend on `safir[gcs]`.
+- Add the `safir.testing.gcs` module, which can be used to mock the Google Cloud Storage API for testing. To use this module, depend on `safir[gcs]`.
 - Add new helper class `safir.pydantic.CamelCaseModel`, which is identical to `pydantic.BaseModel` except with configuration added to accept camel-case keys using the `safir.pydantic.to_camel_case` alias generator and overrides of `dict` and `json` to export in camel-case by default.
 
 ## 3.4.0 (2022-11-29)
 
-- `safir.logging.configure_logging` and `safir.logging.configure_uvicorn_logging` now accept `Profile` and `LogLevel` enums in addition to strings for the `profile` and `log_level` parameters.
-  The new enums are preferred.
-  Support for enums was added in preparation for changing the FastAPI template to use `pydantic.BaseSettings` for its `Configuration` class and validate the values of the `profile` and `log_level` configuration parameters.
-- Add new function `safir.pydantic.normalize_datetime`, which can be used as a Pydantic validator for `datetime` fields.
-  It also allows seconds since epoch as input, and ensures that the resulting `datetime` field in the model is timezone-aware and in UTC.
+### New features
+
+- `safir.logging.configure_logging` and `safir.logging.configure_uvicorn_logging` now accept `Profile` and `LogLevel` enums in addition to strings for the `profile` and `log_level` parameters. The new enums are preferred. Support for enums was added in preparation for changing the FastAPI template to use `pydantic.BaseSettings` for its `Configuration` class and validate the values of the `profile` and `log_level` configuration parameters.
+- Add new function `safir.pydantic.normalize_datetime`, which can be used as a Pydantic validator for `datetime` fields. It also allows seconds since epoch as input, and ensures that the resulting `datetime` field in the model is timezone-aware and in UTC.
 - Add new function `safir.pydantic.to_camel_case`, which can be used as a Pydantic alias generator when a model needs to accept attributes with camel-case names.
 - Add new function `safir.pydantic.validate_exactly_one_of`, which can be used as a model validator to ensure that exactly one of a list of fields was set to a value other than `None`.
-- In `safir.testing.kubernetes.patch_kubernetes`, correctly apply a spec to the mock of `kubernetes_asyncio.client.ApiClient`.
-  Due to an ordering bug in previous versions, the spec was previously a mock object that didn't apply any constraints.
+
+### Bug fixes
+
+- In `safir.testing.kubernetes.patch_kubernetes`, correctly apply a spec to the mock of `kubernetes_asyncio.client.ApiClient`. Due to an ordering bug in previous versions, the spec was previously a mock object that didn't apply any constraints.
 
 ## 3.3.0 (2022-09-15)
 
-- Add new function `safir.logging.configure_uvicorn_logging` that routes Uvicorn logging through structlog for consistent formatting.
-  It also adds context to Uvicorn logs in the format recognized by Google's Cloud Logging.
+### New features
+
+- Add new function `safir.logging.configure_uvicorn_logging` that routes Uvicorn logging through structlog for consistent formatting. It also adds context to Uvicorn logs in the format recognized by Google's Cloud Logging.
 - Support the newer project metadata structure and URL naming used by `pyproject.toml`-only packages in `safir.metadata.get_metadata`.
 
 ## 3.2.0 (2022-05-13)
 
-- New support for [arq](https://arq-docs.helpmanual.io), the Redis-based asyncio distributed queue package.
-  The `safir.arq` module provides an arq client and metadata/result data classes with a mock implementation for testing.
-  The FastAPI dependency, `safir.dependencies.arq.arq_dependency`, provides a convenient way to use the arq client from HTTP handlers.
+### New features
+
+- New support for [arq](https://arq-docs.helpmanual.io), the Redis-based asyncio distributed queue package. The `safir.arq` module provides an arq client and metadata/result data classes with a mock implementation for testing. The FastAPI dependency, `safir.dependencies.arq.arq_dependency`, provides a convenient way to use the arq client from HTTP handlers.
 
 ## 3.1.0 (2022-06-01)
+
+### New features
 
 - Add new FastAPI middleware `CaseInsensitiveQueryMiddleware` to aid in implementing the IVOA protocol requirement that the keys of query parameters be case-insensitive.
 
 ## 3.0.3 (2022-05-16)
 
+### Bug fixes
+
 - Correctly handle the possibility that `request.client` is `None`.
 
 ## 3.0.2 (2022-03-25)
+
+### Bug fixes
 
 - Fix handling of passwords containing special characters such as `@` and `/` in `safir.database`.
 
 ## 3.0.1 (2022-02-24)
 
+### Bug fixes
+
 - `safir.database` retains the port in the database URL, if provided.
 
 ## 3.0.0 (2022-02-23)
 
-- `XForwardedMiddleware` no longer sets ``forwarded_proto` in the request state and instead directly updates the request scope so that subsequent handlers and middleware believe the request scheme is that given by an `X-Forwarded-Proto` header.
-  This fixes the scheme returned by other request methods and attributes such as `url_for` in cases where the service is behind an ingress that terminates TLS.
-- Add new FastAPI dependencies `auth_dependency` and `auth_logger_dependency` from the `safir.dependencies.gafaelfawr` module.
-  `auth_dependency` returns the username of the user authenticated via Gafaelfawr (pulled from the `X-Auth-Request-User` header.
-  `auth_logger_dependency` returns the same logger as `logger_dependency` but with the `user` parameter bound to the username from `auth_dependency`.
-- Add utility functions to initialize a database and create a sync or async session.
-  The session creation functions optionally support a health check to ensure the database schema has been initialized.
+### Backward-incompatible changes
+
+- `XForwardedMiddleware` no longer sets ``forwarded_proto` in the request state and instead directly updates the request scope so that subsequent handlers and middleware believe the request scheme is that given by an `X-Forwarded-Proto` header. This fixes the scheme returned by other request methods and attributes such as `url_for` in cases where the service is behind an ingress that terminates TLS.
+
+### New features
+
+- Add new FastAPI dependencies `auth_dependency` and `auth_logger_dependency` from the `safir.dependencies.gafaelfawr` module. `auth_dependency` returns the username of the user authenticated via Gafaelfawr (pulled from the `X-Auth-Request-User` header. `auth_logger_dependency` returns the same logger as `logger_dependency` but with the `user` parameter bound to the username from `auth_dependency`.
+- Add utility functions to initialize a database and create a sync or async session. The session creation functions optionally support a health check to ensure the database schema has been initialized.
 - Add new FastAPI dependency `db_session_dependency` that creates a task-local async SQLAlchemy session.
 - Add utility functions `datetime_from_db` and `datetime_to_db` to convert between timezone-naive UTC datetimes stored in a database and timezone-aware UTC datetimes used elsewhere in a program.
-- Add a `run_with_async` decorator that runs the decorated async function synchronously.
-  This is primarily useful for decorating Click command functions (for a command-line interface) that need to make async calls.
+- Add a `run_with_async` decorator that runs the decorated async function synchronously. This is primarily useful for decorating Click command functions (for a command-line interface) that need to make async calls.
 
 ## 2.4.2 (2022-01-24)
+
+### New features
 
 - Add a very basic and limited implementation of `list_namespaced_pod` to `safir.testing.kubernetes`.
 
 ## 2.4.1 (2022-01-14)
 
+### Bug fixes
+
 - In the Kubernetes mock API, change the expected body for `patch_namespaced_custom_object_status` to reflect the need to send a JSON patch for the entirety of the `/status` path in order to work around a kubernetes_asyncio bug.
 
 ## 2.4.0 (2022-01-13)
 
-- Add an `initialize_kubernetes` helper function to load Kubernetes configuration.
-  Add the `safir.testing.kubernetes` module, which can be used to mock the Kubernetes API for testing.
-  To use the new Kubernetes support, depend on `safir[kubernetes]`.
+### New features
+
+- Add an `initialize_kubernetes` helper function to load Kubernetes configuration. Add the `safir.testing.kubernetes` module, which can be used to mock the Kubernetes API for testing. To use the new Kubernetes support, depend on `safir[kubernetes]`.
 
 ## 2.3.0 (2021-12-13)
+
+### New features
 
 - When logging in JSON format, use `severity` instead of `level` for the log level for compatibility with Google Log Explorer.
 - In the FastAPI `logger_dependency`, add log information about the incoming requst in a format compatible with Google Log Explorer.
 
 ## 2.2.0 (2021-11-09)
 
-- Restore previous `http_client_dependency` behavior by enabling following redirects by default.
-  This adjusts for the change of defaults in httpx 0.20.0.
+### Bug fixes
+
+- Restore previous `http_client_dependency` behavior by enabling following redirects by default. This adjusts for the change of defaults in httpx 0.20.0.
 
 ## 2.1.1 (2021-10-29)
+
+### Other changes
 
 - Require structlog 21.2.0 and adjust logger configuration of exception handling for the expectations of that version.
 
 ## 2.1.0 (2021-08-09)
 
-- Add `safir.models.ErrorModel`, which is a model of the error message format preferred by FastAPI.
-  Using the model is not necessary but it's helpful to reference it in API documentation to generate more complete information about the error messages.
+### New features
+
+- Add `safir.models.ErrorModel`, which is a model of the error message format preferred by FastAPI. Using the model is not necessary but it's helpful to reference it in API documentation to generate more complete information about the error messages.
+
+### Bug fixes
+
 - Mark all FastAPI dependencies as async so that FastAPI doesn't run them in an external thread pool.
 
 ## 2.0.1 (2021-06-24)
 
-- Defer creation of `httpx.AsyncClient` until the first time it is requested.
-  Allow re-creation after `aclose()`, which makes it easier to write test suites.
+### New features
+
+- Defer creation of `httpx.AsyncClient` until the first time it is requested. Allow re-creation after `aclose()`, which makes it easier to write test suites.
 
 ## 2.0.0 (2021-06-21)
 
-As of this release, Safir is a helper library for FastAPI applications instead of aiohttp applications.
-Much of the library has changed.
-Authors of software that uses Safir should read the documentation again as part of the upgrade to FastAPI.
+### Backward-incompatible changes
+
+As of this release, Safir is a helper library for FastAPI applications instead of aiohttp applications. Much of the library has changed. Authors of software that uses Safir should read the documentation again as part of the upgrade to FastAPI.
 
 Included in this release is:
 
@@ -131,23 +155,25 @@ As of this release, Safir only supports Python 3.8 or later.
 
 ## 1.0.0 (2021-06-18)
 
-Safir v1 will be the major release supporting aiohttp.
-Starting with Safir v2, Safir will become a support library for [FastAPI](https://fastapi.tiangolo.com/) applications.
+Safir v1 will be the major release supporting aiohttp. Starting with Safir v2, Safir will become a support library for [FastAPI](https://fastapi.tiangolo.com/) applications.
 
-This release has no significant difference from 0.2.0.
-The version bump is to indicate that the aiohttp support is stable.
+This release has no significant difference from 0.2.0. The version bump is to indicate that the aiohttp support is stable.
 
 ## 0.2.0 (2021-06-10)
 
+### New features
+
 - `configure_logging` now supports an optional `add_timestamp` parameter (false by default) that adds a timestamp to each log message.
-- Update dependencies.
 
 ## 0.1.1 (2021-01-14)
 
+### Bug fixes
+
 - Fix duplicated log output when logging is configured multiple times.
-- Update dependencies.
 
 ## 0.1.0 (2020-02-26)
+
+### New features
 
 - The first release of Safir featuring:
   

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -5,7 +5,7 @@
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _Roundtable: https://roundtable.lsst.io
 .. _Phalanx: https://phalanx.lsst.io
-.. _fastapi_safir_app: https://github.com/lsst/templates/tree/master/project_templates/fastapi_safir_app
+.. _fastapi_safir_app: https://github.com/lsst/templates/tree/main/project_templates/fastapi_safir_app
 .. _structlog: http://www.structlog.org/en/stable/
 .. _templatekit: https://templatekit.lsst.io
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -106,33 +106,36 @@ The build documentation is located in the :file:`docs/_build/html` directory.
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.rst`).
-Add a description of new features and fixes as list items under a section at the top of the change log called "Unreleased:"
+Each pull request should update the change log (:file:`CHANGELOG.md`).
+Add a description of new features and fixes as list items under a section at the top of the change log, using ``unreleased`` for the date portion.
+The version number for that heading should be chosen or updated based on the semver_ rules.
 
-.. code-block:: rst
+.. _semver: https://semver.org/
 
-   Unreleased
-   ----------
+.. code-block:: markdown
 
-   - Description of the feature or fix.
+   ## X.Y.Z (unreleased)
 
-If the next version is known (because Safir's master branch is being prepared for a new major or minor version), the section may contain that version information:
-
-.. code-block:: rst
-
-   X.Y.0 (unreleased)
-   ------------------
+   ### Subheading (see below)
 
    - Description of the feature or fix.
+
+All changelog entries should be divided into sections (each starting with ``###``) chosen from the following:
+
+- **Backward-incompatible changes** (also increase the major version except in unusual cases)
+- **New features** (also increase the minor version except in unusual cases)
+- **Bug fixes**
+- **Other changes** (which are mostly new features that are not significant enough to call attention to, such as logging formatting changes or updates to the documentation)
 
 If the exact version and release date is known (:doc:`because a release is being prepared <release>`), the section header is formatted as:
 
-.. code-block:: rst
+.. code-block:: markdown
 
-   X.Y.0 (YYYY-MM-DD)
-   ------------------
+   ## X.Y.Z (YYYY-MM-DD)
 
-   - Description of the feature or fix.
+Each entry in the change log should be on one line without line breaks, even though this violates the normal rule of putting a newline after each sentence.
+This allows the whole change log entry to be copied and pasted into the GitHub release page when creating a release.
+Unfortunately, GitHub Markdown preserves line breaks after sentences as hard line breaks when rendering the description of a release.
 
 .. _style-guide:
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -10,15 +10,15 @@ When a semantic version tag is pushed to GitHub, `Safir is released to PyPI`_ wi
 Similarly, documentation is built and pushed for each version (see https://safir.lsst.io/v).
 
 .. _`Safir is released to PyPI`: https://pypi.org/project/safir/
-.. _`ci.yaml`: https://github.com/lsst-sqre/safir/blob/master/.github/workflows/ci.yaml
+.. _`ci.yaml`: https://github.com/lsst-sqre/safir/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
 
 Regular releases
 ================
 
-Regular releases happen from the ``master`` branch after changes have been merged.
-From the ``master`` branch you can release a new major version (``X.0.0``), a new minor version of the current major version (``X.Y.0``), or a new patch of the current major-minor version (``X.Y.Z``).
+Regular releases happen from the ``main`` branch after changes have been merged.
+From the ``main`` branch you can release a new major version (``X.0.0``), a new minor version of the current major version (``X.Y.0``), or a new patch of the current major-minor version (``X.Y.Z``).
 See :ref:`backport-release` to patch an earlier major-minor version.
 
 Release tags are semantic version identifiers following the :pep:`440` specification.
@@ -27,7 +27,7 @@ Release tags are semantic version identifiers following the :pep:`440` specifica
 -------------------------------
 
 Each PR should include updates to the change log.
-If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``master`` branch.
+If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``main`` branch.
 
 In particular, replace the "Unreleased" section headline with the semantic version and date.
 See :ref:`dev-change-log` in the *Developer guide* for details.
@@ -35,7 +35,7 @@ See :ref:`dev-change-log` in the *Developer guide* for details.
 2. Tag the release
 ------------------
 
-At the HEAD of the ``master`` branch, create and push a tag with the semantic version:
+At the HEAD of the ``main`` branch, create and push a tag with the semantic version:
 
 .. code-block:: sh
 
@@ -54,7 +54,7 @@ The `ci.yaml`_ GitHub Actions workflow uploads the new release to PyPI and docum
 Backport releases
 =================
 
-The regular release procedure works from the main line of development on the ``master`` Git branch.
+The regular release procedure works from the main line of development on the ``main`` Git branch.
 To create a release that patches an earlier major or minor version, you need to release from a **release branch.**
 
 Creating a release branch
@@ -72,12 +72,12 @@ If the release branch doesn't already exist, check out the latest patch for that
 Developing on a release branch
 ------------------------------
 
-Once a release branch exists, it becomes the "master" branch for patches of that major-minor version.
+Once a release branch exists, it becomes the "main" branch for patches of that major-minor version.
 Pull requests should be based on, and merged into, the release branch.
 
-If the development on the release branch is a backport of commits on the ``master`` branch, use ``git cherry-pick`` to copy those commits into a new pull request against the release branch.
+If the development on the release branch is a backport of commits on the ``main`` branch, use ``git cherry-pick`` to copy those commits into a new pull request against the release branch.
 
 Releasing from a release branch
 -------------------------------
 
-Releases from a release branch are equivalent to :ref:`regular releases <regular-release>`, except that the release branch takes the role of the ``master`` branch.
+Releases from a release branch are equivalent to :ref:`regular releases <regular-release>`, except that the release branch takes the role of the ``main`` branch.


### PR DESCRIPTION
Adopt the change log format used by Gafaelfawr, which divides change log entries into four standard sections. Document the new format and change the existing entries to match.

Change some references from `master` to `main`.