### PR TITLE
Add support for initialization of non-default schema 

### DIFF
--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.schema import CreateSchema
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.sql.schema import MetaData
 from structlog.stdlib import BoundLogger
@@ -354,6 +355,8 @@ async def initialize_database(
     for _ in range(5):
         try:
             async with engine.begin() as conn:
+                if schema.schema is not None:
+                    await conn.execute(CreateSchema(schema.schema, True))
                 if reset:
                     await conn.run_sync(schema.drop_all)
                 await conn.run_sync(schema.create_all)


### PR DESCRIPTION
SQLAlchemy has support for Postgres-like schemas (in the Posgtres-esque "namespace-of-tables" sense of "schema", not the general "collection of table definitions" sense) and this can be quite useful e.g. as a way of partitioning off dedicated versions of tables for testing so test targets can be executed against a running db server without interfering/colliding with non-test data which may be already loaded there.

It is already reasonably straightforward for a Safir user to set this up in a config-driven way in their SQLAlchemy `Base` ORM declaration:

```Python
from sqlalchemy import MetaData
from sqlalchemy.orm import DeclarativeBase

from ..config import config

class Base(DeclarativeBase):
    metadata = MetaData(schema=config.database_schema)
```
...where `database_schema` is a `str | None` with a default of `None`.  There is a problem however, because the stock Postgres Docker container only creates the default ("public") schema, so Safir database initialization with a non-default schema fails with "schema does not exist".

This PR adds a clause to `initialize_database` use SQLAlchemy to create the schema at that time if it is non-default (non-`None`), and does not already exist.

More here:
https://docs.sqlalchemy.org/en/20/core/metadata.html#specifying-the-schema-name
https://www.postgresql.org/docs/current/ddl-schemas.html