### PR TITLE
DM-38466: Require Python 3.11 and use it for type annotations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -38,9 +38,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
           - "3.11"
 
     steps:
@@ -68,7 +65,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-linkcheck"
 
       # Only attempt documentation uploads for tagged releases and pull
@@ -100,5 +97,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
-          python-version: "3.10"
+          python-version: "3.11"
           upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.1.0]
-        args: [-l, '76', -t, py39]
+        args: [-l, '76', -t, py311]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
+## 4.0.0 (unreleased)
+
+### Backwards-incompatible changes
+
+- Safir now requires a minimum Python version of 3.11.
+
 ## 3.8.0 (2023-03-15)
 
 ### New features

--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -98,7 +98,7 @@ The :file:`src/yourapp/worker/main.py` module looks like:
     from __future__ import annotations
 
     import uuid
-    from typing import Any, Dict
+    from typing import Any
 
     import httpx
     import structlog
@@ -108,7 +108,7 @@ The :file:`src/yourapp/worker/main.py` module looks like:
     from .functions import function_a, function_b
 
 
-    async def startup(ctx: Dict[Any, Any]) -> None:
+    async def startup(ctx: dict[Any, Any]) -> None:
         """Runs during worker start-up to set up the worker context."""
         configure_logging(
             profile=config.profile,
@@ -127,7 +127,7 @@ The :file:`src/yourapp/worker/main.py` module looks like:
         logger.info("Worker start up complete")
 
 
-    async def shutdown(ctx: Dict[Any, Any]) -> None:
+    async def shutdown(ctx: dict[Any, Any]) -> None:
         """Runs during worker shutdown to cleanup resources."""
         if "logger" in ctx.keys():
             logger = ctx["logger"]
@@ -172,6 +172,8 @@ The `safir.dependencies.arq.arq_dependency` dependency provides your FastAPI end
 
 .. code-block:: python
 
+    from typing import Any
+
     from fastapi import Depends, HTTPException
     from safir.arq import ArqQueue
     from safir.dependencies.arq import arq_dependency
@@ -182,7 +184,7 @@ The `safir.dependencies.arq.arq_dependency` dependency provides your FastAPI end
         arq_queue: ArqQueue = Depends(arq_dependency),
         a: str = "hello",
         b: int = 42,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Create a job."""
         job = await arq_queue.enqueue("test_task", a, a_number=b)
         return {"job_id": job.id}
@@ -192,7 +194,7 @@ The `safir.dependencies.arq.arq_dependency` dependency provides your FastAPI end
     async def get_job(
         job_id: str,
         arq_queue: ArqQueue = Depends(arq_dependency),
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get metadata about a job."""
         try:
             job = await arq_queue.get_job_metadata(

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -296,7 +296,7 @@ For example:
 
 .. code-block:: python
 
-   from typing import AsyncIterator
+   from collections.abc import AsyncIterator
 
    import pytest_asyncio
    from asgi_lifespan import LifespanManager

--- a/docs/user-guide/gafaelfawr.rst
+++ b/docs/user-guide/gafaelfawr.rst
@@ -54,7 +54,7 @@ This is most easily done by defining a fixture, as follows.
 
 .. code-block:: python
 
-   from typing import AsyncIterator
+   from collections.abc import AsyncIterator
 
    import pytest_asyncio
    from fastapi import FastAPI

--- a/docs/user-guide/gcs.rst
+++ b/docs/user-guide/gcs.rst
@@ -54,11 +54,10 @@ Applications that want to run tests with the mock GCS API should define a fixtur
 
 .. code-block:: python
 
+   from collections.abc import Iterator
    from datetime import timedelta
-   from typing import Iterator
 
    import pytest
-
    from safir.testing.gcs import MockStorageClient, patch_google_storage
 
 

--- a/docs/user-guide/kubernetes.rst
+++ b/docs/user-guide/kubernetes.rst
@@ -40,10 +40,9 @@ Applications that want to run tests with the mock Kubernetes API should define a
 
 .. code-block:: python
 
-   from typing import Iterator
+   from collections.abc import Iterator
 
    import pytest
-
    from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi",
     "httpx>=0.20.0",
@@ -108,7 +105,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ["py311"]
 exclude = '''
 /(
     \.eggs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,14 @@ plugins = [
     "pydantic.mypy",
     "sqlalchemy.ext.mypy.plugin",
 ]
+show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true

--- a/src/safir/arq.py
+++ b/src/safir/arq.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional, Self
 
 from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
@@ -39,12 +39,12 @@ class ArqJobError(Exception):
         The job ID, or `None` if the job ID is not known in this context.
     """
 
-    def __init__(self, message: str, job_id: Optional[str]) -> None:
+    def __init__(self, message: str, job_id: str | None) -> None:
         super().__init__(message)
         self._job_id = job_id
 
     @property
-    def job_id(self) -> Optional[str]:
+    def job_id(self) -> str | None:
         """The job ID, or `None` if the job ID is not known in this context."""
         return self._job_id
 
@@ -52,7 +52,7 @@ class ArqJobError(Exception):
 class JobNotQueued(ArqJobError):
     """The job was not successfully queued."""
 
-    def __init__(self, job_id: Optional[str]) -> None:
+    def __init__(self, job_id: str | None) -> None:
         super().__init__(
             f"Job was not queued because it already exists. id={job_id}",
             job_id,
@@ -122,10 +122,10 @@ class JobMetadata:
     name: str
     """The task name."""
 
-    args: Tuple[Any, ...]
+    args: tuple[Any, ...]
     """The positional arguments to the task function."""
 
-    kwargs: Dict[str, Any]
+    kwargs: dict[str, Any]
     """The keyword arguments to the task function."""
 
     enqueue_time: datetime
@@ -148,7 +148,7 @@ class JobMetadata:
     """Name of the queue this job belongs to."""
 
     @classmethod
-    async def from_job(cls, job: Job) -> JobMetadata:
+    async def from_job(cls, job: Job) -> Self:
         """Initialize JobMetadata from an arq Job.
 
         Raises
@@ -230,7 +230,7 @@ class JobResult(JobMetadata):
     """The job's result."""
 
     @classmethod
-    async def from_job(cls, job: Job) -> JobResult:
+    async def from_job(cls, job: Job) -> Self:
         """Initialize the `JobResult` from an arq `~arq.jobs.Job`.
 
         Raises
@@ -399,7 +399,7 @@ class RedisArqQueue(ArqQueue):
         redis_settings: RedisSettings,
         *,
         default_queue_name: str = arq_default_queue_name,
-    ) -> RedisArqQueue:
+    ) -> Self:
         """Initialize a RedisArqQueue from Redis settings."""
         pool = await create_pool(
             redis_settings, default_queue_name=default_queue_name
@@ -452,14 +452,14 @@ class MockArqQueue(ArqQueue):
         self, *, default_queue_name: str = arq_default_queue_name
     ) -> None:
         super().__init__(default_queue_name=default_queue_name)
-        self._job_metadata: Dict[str, Dict[str, JobMetadata]] = {
+        self._job_metadata: dict[str, dict[str, JobMetadata]] = {
             self.default_queue_name: {}
         }
-        self._job_results: Dict[str, Dict[str, JobResult]] = {
+        self._job_results: dict[str, dict[str, JobResult]] = {
             self.default_queue_name: {}
         }
 
-    def _resolve_queue_name(self, queue_name: Optional[str]) -> str:
+    def _resolve_queue_name(self, queue_name: str | None) -> str:
         return queue_name or self.default_queue_name
 
     async def enqueue(

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any, Callable, Coroutine, TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 

--- a/src/safir/database.py
+++ b/src/safir/database.py
@@ -38,7 +38,7 @@ class DatabaseInitializationError(Exception):
 
 
 def _build_database_url(
-    url: str, password: Optional[str], *, is_async: bool
+    url: str, password: str | None, *, is_async: bool
 ) -> str:
     """Build the authenticated URL for the database.
 
@@ -91,7 +91,7 @@ def datetime_from_db(time: None) -> None:
     ...
 
 
-def datetime_from_db(time: Optional[datetime]) -> Optional[datetime]:
+def datetime_from_db(time: datetime | None) -> datetime | None:
     """Add the UTC time zone to a naive datetime from the database.
 
     Parameters
@@ -122,7 +122,7 @@ def datetime_to_db(time: None) -> None:
     ...
 
 
-def datetime_to_db(time: Optional[datetime]) -> Optional[datetime]:
+def datetime_to_db(time: datetime | None) -> datetime | None:
     """Strip time zone for storing a datetime in the database.
 
     Parameters
@@ -147,7 +147,7 @@ def datetime_to_db(time: Optional[datetime]) -> Optional[datetime]:
 
 def create_database_engine(
     url: str,
-    password: Optional[str],
+    password: str | None,
     *,
     isolation_level: Optional[str] = None,
 ) -> AsyncEngine:
@@ -246,7 +246,7 @@ async def create_async_session(
 
 def create_sync_session(
     url: str,
-    password: Optional[str],
+    password: str | None,
     logger: Optional[BoundLogger] = None,
     *,
     isolation_level: Optional[str] = None,

--- a/src/safir/datetime.py
+++ b/src/safir/datetime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional, overload
+from typing import overload
 
 __all__ = [
     "current_datetime",
@@ -53,9 +53,7 @@ def format_datetime_for_logging(timestamp: None) -> None:
     ...
 
 
-def format_datetime_for_logging(
-    timestamp: Optional[datetime],
-) -> Optional[str]:
+def format_datetime_for_logging(timestamp: datetime | None) -> str | None:
     """Format a datetime for logging and human readabilty.
 
     Parameters
@@ -113,7 +111,7 @@ def isodatetime(timestamp: datetime) -> str:
     return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def parse_isodatetime(time_string: str) -> Optional[datetime]:
+def parse_isodatetime(time_string: str) -> datetime | None:
     """Parse a string in a standard ISO date format.
 
     Parameters

--- a/src/safir/dependencies/arq.py
+++ b/src/safir/dependencies/arq.py
@@ -22,7 +22,7 @@ class ArqDependency:
         self._arq_queue: Optional[ArqQueue] = None
 
     async def initialize(
-        self, *, mode: ArqMode, redis_settings: Optional[RedisSettings]
+        self, *, mode: ArqMode, redis_settings: RedisSettings | None
     ) -> None:
         """Initialize the dependency (call during the FastAPI start-up event).
 

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -1,6 +1,7 @@
 """Manage an async database session."""
 
-from typing import AsyncIterator, Optional
+from collections.abc import AsyncIterator
+from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
 
@@ -66,7 +67,7 @@ class DatabaseSessionDependency:
     async def initialize(
         self,
         url: str,
-        password: Optional[str],
+        password: str | None,
         *,
         isolation_level: Optional[str] = None,
     ) -> None:

--- a/src/safir/gcs.py
+++ b/src/safir/gcs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Optional
 from urllib.parse import urlparse
 
 import google.auth
@@ -49,7 +48,7 @@ class SignedURLService:
         self._gcs = storage.Client()
         self._credentials, _ = google.auth.default()
 
-    def signed_url(self, uri: str, mime_type: Optional[str]) -> str:
+    def signed_url(self, uri: str, mime_type: str | None) -> str:
         """Generate signed URL for a given storage object.
 
         Parameters

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -7,7 +7,7 @@ import logging.config
 import re
 import sys
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Optional
 
 import structlog
 from structlog.stdlib import add_log_level
@@ -92,8 +92,8 @@ def add_log_severity(
 def configure_logging(
     *,
     name: str,
-    profile: Union[Profile, str] = Profile.production,
-    log_level: Union[LogLevel, str] = LogLevel.INFO,
+    profile: Profile | str = Profile.production,
+    log_level: LogLevel | str = LogLevel.INFO,
     add_timestamp: bool = False,
 ) -> None:
     """Configure logging and structlog.
@@ -167,7 +167,7 @@ def configure_logging(
     logger.addHandler(stream_handler)
     logger.setLevel(log_level.value)
 
-    processors: List[Any] = [
+    processors: list[Any] = [
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.PositionalArgumentsFormatter(),
@@ -247,7 +247,7 @@ def _process_uvicorn_access_log(
 
 
 def configure_uvicorn_logging(
-    log_level: Union[LogLevel, str] = LogLevel.INFO,
+    log_level: LogLevel | str = LogLevel.INFO,
 ) -> None:
     """Set up logging.
 

--- a/src/safir/middleware/ivoa.py
+++ b/src/safir/middleware/ivoa.py
@@ -1,6 +1,6 @@
 """Middleware for IVOA services."""
 
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from urllib.parse import urlencode
 
 from fastapi import Request, Response

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from ipaddress import _BaseAddress, _BaseNetwork, ip_address
-from typing import Awaitable, Callable, List, Optional
+from typing import Optional
 
 from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -38,7 +39,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
     """
 
     def __init__(
-        self, app: FastAPI, *, proxies: Optional[List[_BaseNetwork]] = None
+        self, app: FastAPI, *, proxies: Optional[list[_BaseNetwork]] = None
     ) -> None:
         super().__init__(app)
         if proxies:
@@ -108,7 +109,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
         return await call_next(request)
 
-    def _get_forwarded_for(self, request: Request) -> List[_BaseAddress]:
+    def _get_forwarded_for(self, request: Request) -> list[_BaseAddress]:
         """Retrieve the ``X-Forwarded-For`` entries from the request.
 
         Parameters
@@ -132,7 +133,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
             if addr
         ]
 
-    def _get_forwarded_host(self, request: Request) -> Optional[str]:
+    def _get_forwarded_host(self, request: Request) -> str | None:
         """Retrieve the ``X-Forwarded-Host`` header.
 
         Parameters
@@ -153,7 +154,7 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
             return None
         return forwarded_host[0].strip()
 
-    def _get_forwarded_proto(self, request: Request) -> List[str]:
+    def _get_forwarded_proto(self, request: Request) -> list[str]:
         """Retrieve the ``X-Forwarded-Proto`` entries from the request.
 
         Parameters

--- a/src/safir/models.py
+++ b/src/safir/models.py
@@ -8,7 +8,7 @@ generate good documentation.
 """
 
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -35,7 +35,7 @@ class ErrorLocation(str, Enum):
 class ErrorDetail(BaseModel):
     """The detail of the error message."""
 
-    loc: Optional[List[str]] = Field(
+    loc: Optional[list[str]] = Field(
         None, title="Location", example=["area", "field"]
     )
 
@@ -47,4 +47,4 @@ class ErrorDetail(BaseModel):
 class ErrorModel(BaseModel):
     """A structured API error message."""
 
-    detail: List[ErrorDetail] = Field(..., title="Detail")
+    detail: list[ErrorDetail] = Field(..., title="Detail")

--- a/src/safir/slack/blockkit.py
+++ b/src/safir/slack/blockkit.py
@@ -25,6 +25,13 @@ __all__ = [
 class SlackBaseBlock(BaseModel, metaclass=ABCMeta):
     """Base class for any Slack Block Kit block."""
 
+    max_formatted_length: ClassVar[int] = 3000
+    """Maximum length of formatted output, imposed by Slack.
+
+    Intended to be overridden by child classes that need to impose different
+    maximum lengths.
+    """
+
     @abstractmethod
     def to_slack(self) -> Dict[str, Any]:
         """Convert to a Slack Block Kit block.
@@ -52,13 +59,6 @@ class SlackTextBlock(SlackBaseBlock):
 
     This is always marked as vertabim, so channel mentions or @-mentions of
     users will not be treated as special.
-    """
-
-    max_formatted_length: ClassVar[int] = 3000
-    """Maximum length of formatted output, imposed by Slack.
-
-    Intended to be overridden by child classes that need to impose different
-    maximum lengths.
     """
 
     def to_slack(self) -> Dict[str, Any]:
@@ -89,13 +89,6 @@ class SlackCodeBlock(SlackBaseBlock):
     code: str
     """Text of the field as a code block."""
 
-    max_formatted_length: ClassVar[int] = 3000
-    """Maximum length of formatted output, imposed by Slack.
-
-    Intended to be overridden by child classes that need to impose different
-    maximum lengths.
-    """
-
     def to_slack(self) -> Dict[str, Any]:
         """Convert to a Slack Block Kit block.
 
@@ -116,7 +109,7 @@ class SlackCodeBlock(SlackBaseBlock):
 class SlackBaseField(SlackBaseBlock):
     """Base class for Slack Block Kit blocks for the ``fields`` section."""
 
-    max_formatted_length = 2000
+    max_formatted_length: ClassVar[int] = 2000
 
 
 class SlackTextField(SlackTextBlock, SlackBaseField):
@@ -278,7 +271,7 @@ class SlackException(Exception):
             Slack message suitable for posting with `SlackClient`.
         """
         failed_at = format_datetime_for_logging(self.failed_at)
-        fields = [
+        fields: List[SlackBaseField] = [
             SlackTextField(heading="Exception type", text=type(self).__name__),
             SlackTextField(heading="Failed at", text=failed_at),
         ]

--- a/src/safir/slack/blockkit.py
+++ b/src/safir/slack/blockkit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Optional
 
 from pydantic import BaseModel, validator
 
@@ -33,7 +33,7 @@ class SlackBaseBlock(BaseModel, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def to_slack(self) -> Dict[str, Any]:
+    def to_slack(self) -> dict[str, Any]:
         """Convert to a Slack Block Kit block.
 
         Returns
@@ -61,7 +61,7 @@ class SlackTextBlock(SlackBaseBlock):
     users will not be treated as special.
     """
 
-    def to_slack(self) -> Dict[str, Any]:
+    def to_slack(self) -> dict[str, Any]:
         """Convert to a Slack Block Kit block.
 
         Returns
@@ -89,7 +89,7 @@ class SlackCodeBlock(SlackBaseBlock):
     code: str
     """Text of the field as a code block."""
 
-    def to_slack(self) -> Dict[str, Any]:
+    def to_slack(self) -> dict[str, Any]:
         """Convert to a Slack Block Kit block.
 
         Returns
@@ -159,13 +159,13 @@ class SlackMessage(BaseModel):
     this to `False` with untrusted input.
     """
 
-    fields: List[SlackBaseField] = []
+    fields: list[SlackBaseField] = []
     """Short key/value fields to include in the message (at most 10)."""
 
-    blocks: List[SlackBaseBlock] = []
+    blocks: list[SlackBaseBlock] = []
     """Additional text blocks to include in the message (after fields)."""
 
-    attachments: List[SlackBaseBlock] = []
+    attachments: list[SlackBaseBlock] = []
     """Longer sections to include as attachments.
 
     Notes
@@ -178,7 +178,7 @@ class SlackMessage(BaseModel):
     """
 
     @validator("fields")
-    def _validate_fields(cls, v: List[SlackBaseField]) -> List[SlackBaseField]:
+    def _validate_fields(cls, v: list[SlackBaseField]) -> list[SlackBaseField]:
         """Check constraints on fields.
 
         Slack imposes a maximum of 10 items in a ``fields`` array. Also ensure
@@ -191,7 +191,7 @@ class SlackMessage(BaseModel):
             raise ValueError(msg)
         return v
 
-    def to_slack(self) -> Dict[str, Any]:
+    def to_slack(self) -> dict[str, Any]:
         """Convert to a Slack Block Kit message.
 
         Returns
@@ -271,7 +271,7 @@ class SlackException(Exception):
             Slack message suitable for posting with `SlackClient`.
         """
         failed_at = format_datetime_for_logging(self.failed_at)
-        fields: List[SlackBaseField] = [
+        fields: list[SlackBaseField] = [
             SlackTextField(heading="Exception type", text=type(self).__name__),
             SlackTextField(heading="Failed at", text=failed_at),
         ]

--- a/src/safir/testing/gcs.py
+++ b/src/safir/testing/gcs.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from io import BufferedReader
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 from google.cloud import storage

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -6,7 +6,8 @@ import copy
 import os
 import re
 import uuid
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from collections.abc import Callable, Iterator
+from typing import Any, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 from kubernetes_asyncio import client, config
@@ -49,10 +50,10 @@ class MockKubernetesApi:
 
     def __init__(self) -> None:
         self.error_callback: Optional[Callable[..., None]] = None
-        self.objects: Dict[str, Dict[str, Dict[str, Any]]] = {}
-        self.custom_kinds: Dict[str, str] = {}
+        self.objects: dict[str, dict[str, dict[str, Any]]] = {}
+        self.custom_kinds: dict[str, str] = {}
 
-    def get_all_objects_for_test(self, kind: str) -> List[Any]:
+    def get_all_objects_for_test(self, kind: str) -> list[Any]:
         """Return all objects of a given kind sorted by namespace and name.
 
         Parameters
@@ -124,7 +125,7 @@ class MockKubernetesApi:
         version: str,
         namespace: str,
         plural: str,
-        body: Dict[str, Any],
+        body: dict[str, Any],
     ) -> None:
         self._maybe_error(
             "create_namespaced_custom_object",
@@ -151,7 +152,7 @@ class MockKubernetesApi:
         namespace: str,
         plural: str,
         name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         self._maybe_error(
             "get_namespaced_custom_object",
             group,
@@ -164,7 +165,7 @@ class MockKubernetesApi:
 
     async def list_cluster_custom_object(
         self, group: str, version: str, plural: str
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         self._maybe_error("list_cluster_custom_object", group, version, plural)
         key = f"{group}/{version}/{plural}"
         results = []
@@ -180,8 +181,8 @@ class MockKubernetesApi:
         namespace: str,
         plural: str,
         name: str,
-        body: List[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        body: list[dict[str, Any]],
+    ) -> dict[str, Any]:
         self._maybe_error(
             "patch_namespaced_custom_object_status",
             group,
@@ -206,7 +207,7 @@ class MockKubernetesApi:
         namespace: str,
         plural: str,
         name: str,
-        body: Dict[str, Any],
+        body: dict[str, Any],
     ) -> None:
         self._maybe_error(
             "replace_namespaced_custom_object",
@@ -278,7 +279,7 @@ class MockKubernetesApi:
         self._store_object(namespace, "Secret", secret.metadata.name, secret)
 
     async def patch_namespaced_secret(
-        self, name: str, namespace: str, body: List[Dict[str, Any]]
+        self, name: str, namespace: str, body: list[dict[str, Any]]
     ) -> V1Secret:
         self._maybe_error("patch_namespaced_secret", name, namespace)
         obj = copy.deepcopy(self._get_object(namespace, "Secret", name))

--- a/src/safir/testing/slack.py
+++ b/src/safir/testing/slack.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 import respx
 from httpx import Request, Response
@@ -24,7 +24,7 @@ class MockSlackWebhook:
 
     def __init__(self, url: str) -> None:
         self.url = url
-        self.messages: List[Dict[str, Any]] = []
+        self.messages: list[dict[str, Any]] = []
 
     def post_webhook(self, request: Request) -> Response:
         """Callback called whenever a Slack message is posted.

--- a/src/safir/testing/uvicorn.py
+++ b/src/safir/testing/uvicorn.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 __all__ = [
     "ServerNotListeningError",
@@ -84,7 +84,7 @@ def spawn_uvicorn(
     factory: Optional[str] = None,
     capture: bool = False,
     timeout: float = 5.0,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[dict[str, str]] = None,
 ) -> UvicornProcess:
     """Spawn an ASGI app as a separate Uvicorn process.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import timedelta
-from typing import Iterator
 
 import pytest
 import respx

--- a/tests/dependencies/arq_test.py
+++ b/tests/dependencies/arq_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import pytest
 from arq.constants import default_queue_name
@@ -22,7 +22,7 @@ async def test_arq_dependency_mock() -> None:
     @app.post("/")
     async def post_job(
         arq_queue: MockArqQueue = Depends(arq_dependency),
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Create a job."""
         job = await arq_queue.enqueue("test_task", "hello", a_number=42)
         return {
@@ -39,7 +39,7 @@ async def test_arq_dependency_mock() -> None:
         job_id: str,
         queue_name: Optional[str] = None,
         arq_queue: MockArqQueue = Depends(arq_dependency),
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get metadata about a job."""
         try:
             job = await arq_queue.get_job_metadata(
@@ -61,7 +61,7 @@ async def test_arq_dependency_mock() -> None:
         job_id: str,
         queue_name: Optional[str] = None,
         arq_queue: MockArqQueue = Depends(arq_dependency),
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get the results for a job."""
         try:
             job_result = await arq_queue.get_job_result(

--- a/tests/dependencies/db_session_test.py
+++ b/tests/dependencies/db_session_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from typing import List
 
 import pytest
 import structlog
@@ -57,7 +56,7 @@ async def test_session() -> None:
     @app.get("/list")
     async def get_list(
         session: async_scoped_session = Depends(db_session_dependency),
-    ) -> List[str]:
+    ) -> list[str]:
         async with session.begin():
             result = await session.scalars(select(User.username))
             return list(result.all())

--- a/tests/dependencies/gafaelfawr_test.py
+++ b/tests/dependencies/gafaelfawr_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Dict
 from unittest.mock import ANY
 
 import pytest
@@ -24,7 +23,7 @@ async def test_auth_dependency() -> None:
     app = FastAPI()
 
     @app.get("/")
-    async def handler(user: str = Depends(auth_dependency)) -> Dict[str, str]:
+    async def handler(user: str = Depends(auth_dependency)) -> dict[str, str]:
         return {"user": user}
 
     async with AsyncClient(app=app, base_url="https://example.com") as client:
@@ -45,7 +44,7 @@ async def test_auth_logger_dependency(caplog: LogCaptureFixture) -> None:
     @app.get("/")
     async def handler(
         logger: BoundLogger = Depends(auth_logger_dependency),
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         logger.info("something")
         return {}
 

--- a/tests/dependencies/http_client_test.py
+++ b/tests/dependencies/http_client_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
-
 import pytest
 import respx
 from asgi_lifespan import LifespanManager
@@ -14,7 +12,7 @@ from safir.dependencies.http_client import http_client_dependency
 
 
 @pytest.fixture
-def non_mocked_hosts() -> List[str]:
+def non_mocked_hosts() -> list[str]:
     return ["example.com"]
 
 
@@ -26,7 +24,7 @@ async def test_http_client(respx_mock: respx.Router) -> None:
     @app.get("/")
     async def handler(
         http_client: AsyncClient = Depends(http_client_dependency),
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         assert isinstance(http_client, AsyncClient)
         await http_client.get("https://www.google.com")
         return {}

--- a/tests/dependencies/logger_test.py
+++ b/tests/dependencies/logger_test.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Dict
 from unittest.mock import ANY
 
 import pytest
+from _pytest.logging import LogCaptureFixture
 from fastapi import Depends, FastAPI
 from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
@@ -14,9 +14,6 @@ from structlog.stdlib import BoundLogger
 from safir.dependencies.logger import logger_dependency
 from safir.logging import configure_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
-
-if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
 
 
 @pytest.mark.asyncio
@@ -28,7 +25,7 @@ async def test_logger(caplog: LogCaptureFixture) -> None:
     @app.get("/")
     async def handler(
         logger: BoundLogger = Depends(logger_dependency),
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         logger.info("something", param="value")
         return {}
 
@@ -65,7 +62,7 @@ async def test_logger_xforwarded(caplog: LogCaptureFixture) -> None:
     @app.get("/")
     async def handler(
         logger: BoundLogger = Depends(logger_dependency),
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         logger.info("something", param="value")
         return {}
 

--- a/tests/middleware/ivoa_test.py
+++ b/tests/middleware/ivoa_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
@@ -23,7 +21,7 @@ async def test_case_insensitive() -> None:
     app = build_app()
 
     @app.get("/")
-    async def handler(param: str) -> Dict[str, str]:
+    async def handler(param: str) -> dict[str, str]:
         return {"param": param}
 
     async with AsyncClient(app=app, base_url="https://example.com") as client:

--- a/tests/middleware/x_forwarded_test.py
+++ b/tests/middleware/x_forwarded_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ipaddress import _BaseNetwork, ip_network
-from typing import Dict, List, Optional
+from typing import Optional
 
 import pytest
 from fastapi import FastAPI, Request
@@ -12,7 +12,7 @@ from httpx import AsyncClient
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 
-def build_app(proxies: Optional[List[_BaseNetwork]] = None) -> FastAPI:
+def build_app(proxies: Optional[list[_BaseNetwork]] = None) -> FastAPI:
     """Construct a test FastAPI app with the middleware registered."""
     app = FastAPI()
     app.add_middleware(XForwardedMiddleware, proxies=proxies)
@@ -24,7 +24,7 @@ async def test_ok() -> None:
     app = build_app([ip_network("11.0.0.0/8")])
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert request.client
         assert request.client.host == "10.10.10.10"
         assert request.state.forwarded_host == "foo.example.com"
@@ -49,7 +49,7 @@ async def test_defaults() -> None:
     app = build_app()
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert request.client
         assert request.client.host == "192.168.0.1"
         assert request.state.forwarded_host == "foo.example.com"
@@ -73,7 +73,7 @@ async def test_no_forwards() -> None:
     app = build_app([ip_network("127.0.0.1")])
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert not request.state.forwarded_host
         assert request.client
         assert request.client.host == "127.0.0.1"
@@ -90,7 +90,7 @@ async def test_all_filtered() -> None:
     app = build_app([ip_network("10.0.0.0/8")])
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert request.client
         assert request.client.host == "10.10.10.10"
         assert request.state.forwarded_host == "foo.example.com"
@@ -114,7 +114,7 @@ async def test_one_proto() -> None:
     app = build_app([ip_network("11.11.11.11")])
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert request.client
         assert request.client.host == "10.10.10.10"
         assert request.state.forwarded_host == "foo.example.com"
@@ -138,7 +138,7 @@ async def test_no_proto_or_host() -> None:
     app = build_app([ip_network("11.11.11.11")])
 
     @app.get("/")
-    async def handler(request: Request) -> Dict[str, str]:
+    async def handler(request: Request) -> dict[str, str]:
         assert not request.state.forwarded_host
         assert request.client
         assert request.client.host == "10.10.10.10"

--- a/tests/slack/blockkit_test.py
+++ b/tests/slack/blockkit_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 from pydantic import ValidationError
 
@@ -159,7 +157,7 @@ def test_message() -> None:
 
 def test_validation() -> None:
     """Test errors caught by validation."""
-    fields: List[SlackBaseField] = [
+    fields: list[SlackBaseField] = [
         SlackTextField(heading="Something", text="foo")
     ] * 11
     message = SlackMessage(message="Ten fields", fields=fields[:10])

--- a/tests/slack/blockkit_test.py
+++ b/tests/slack/blockkit_test.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from typing import List
+
 import pytest
 from pydantic import ValidationError
 
 from safir.slack.blockkit import (
+    SlackBaseField,
     SlackCodeBlock,
     SlackCodeField,
     SlackMessage,
@@ -156,7 +159,9 @@ def test_message() -> None:
 
 def test_validation() -> None:
     """Test errors caught by validation."""
-    fields = [SlackTextField(heading="Something", text="foo")] * 11
+    fields: List[SlackBaseField] = [
+        SlackTextField(heading="Something", text="foo")
+    ] * 11
     message = SlackMessage(message="Ten fields", fields=fields[:10])
     assert len(message.fields) == 10
     with pytest.raises(ValidationError):

--- a/tests/testing/conftest.py
+++ b/tests/testing/conftest.py
@@ -6,9 +6,9 @@ that they can be exercised in tests of the test support infrastructure.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import timedelta
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 

--- a/tests/testing/kubernetes_test.py
+++ b/tests/testing/kubernetes_test.py
@@ -6,7 +6,7 @@ the basic calls work.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import ANY
 
 import pytest
@@ -25,7 +25,7 @@ async def test_initialize(mock_kubernetes: MockKubernetesApi) -> None:
 
 @pytest.mark.asyncio
 async def test_mock(mock_kubernetes: MockKubernetesApi) -> None:
-    custom: Dict[str, Any] = {
+    custom: dict[str, Any] = {
         "apiVersion": "gafaelfawr.lsst.io/v1alpha1",
         "kind": "GafaelfawrServiceToken",
         "metadata": {


### PR DESCRIPTION
- Set Python 3.11 to the minimum version and update GitHub Actions and other configuration accordingly
- Enable additional mypy checks for Pydantic models and adjust the code accordingly (fixing a multiple inheritance problem with maximum lengths of Slack messages)
- Import types from `collections.abc` instead of `typing` when possible
- Use `dict`, `list`, and `tuple` in types instead of their `typing` equivalents
- Use the `|` syntax instead of `Union`, and instead of `Optional` in cases where the parameter is not optional but may be `None`
- Use `Self` as the return type for class method constructors
- Redo how the `dict` and `json` overrides in `CamelCaseModel` are typed: use a decorator to copy the type signature from the parent method, allowing the override to be written using `kwargs` and therefore be agnostic to changes to the parent type signature without losing all typing information