### PR TITLE
DM-38466: Suppress pkg_resources warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,9 @@ skip = ["docs/conf.py"]
 asyncio_mode = "strict"
 filterwarnings = [
     "ignore:'cgi' is deprecated:DeprecationWarning:google.cloud.storage.blob",
+    # Google modules call a deprecated pkg_resources API.
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
 ]
 python_files = [
     "tests/*.py",


### PR DESCRIPTION
The Google cloud Python packages use pkg_resources, and therefore spew warnings when imported. We can't do anything about those and presumably they'll eventually be fixed upstream, so suppress them.