### PR TITLE
DM-38533: Exclude X-Auth-Request-User from the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ X.Y.Z (YYYY-MM-DD)
   A `safir.redis.EncryptedPydanticRedisStorage` class also encrypts data in Redis.
   To use the `safir.redis` module, install Safir with the `redis` extra (i.e., `pip install safir[redis]`).
 
+### Bug fixes
+
+- Stop adding the `X-Auth-Request-User` header to the OpenAPI schema for routes that use `auth_dependency` or `auth_logger_dependency`.
+
 ## 3.8.0 (2023-03-15)
 
 ### New features

--- a/src/safir/dependencies/gafaelfawr.py
+++ b/src/safir/dependencies/gafaelfawr.py
@@ -11,7 +11,9 @@ __all__ = [
 ]
 
 
-async def auth_dependency(x_auth_request_user: str = Header(...)) -> str:
+async def auth_dependency(
+    x_auth_request_user: str = Header(..., include_in_schema=False)
+) -> str:
     """Retrieve authentication information from HTTP headers.
 
     Intended for use with applications protected by Gafaelfawr, this retrieves


### PR DESCRIPTION
auth_dependency and auth_logger_dependency pull the username from the X-Auth-Request-User header, set by Gafaelfawr. By default, any header parameters like this are also added to the OpenAPI schema of routes that use them. However, in this case that addition is incorrect; X-Auth-Request-User is an internal implementation detail of Gafaelfawr-protected applications, not a header that the user can or should supply. Suppress it from the schema accordingly.