### PR TITLE
DM-38533: Merge Kubernetes API mock with lab controller work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,25 @@ X.Y.Z (YYYY-MM-DD)
 ### Backwards-incompatible changes
 
 - Safir now requires a minimum Python version of 3.11.
+- Custom Kubernetes objects are no longer copied before being stored in the Kubernetes mock by `create_namespaced_custom_object`, and no longer automatically get a `metadata.uid` value. This brings handling of custom objects in line with the behavior of other mocked `create_*` and `replace_*` APIs.
+- All objects stored in the Kubernetes mock will be modified to set `api_version`, `kind`, and (where appropriate) `namespace`. If any of those values are set in the object, they are checked for correctness and rejected with `AssertionError` if they don't match the API call and its parameters.
+- The mocked `create_*` Kubernetes APIs now use the name `body` for the parameter containing the API object, instead of using some other name specific to the kind of object. This fixes compatibility with the Python Kubernetes API that this class is mocking.
 
 ### New features
 
 - The new `safir.redis.PydanticRedisStorage` class enables you to store Pydantic model objects in Redis.
   A `safir.redis.EncryptedPydanticRedisStorage` class also encrypts data in Redis.
   To use the `safir.redis` module, install Safir with the `redis` extra (i.e., `pip install safir[redis]`).
+- Add a `safir.testing.kubernetes.strip_none` helper function that makes it easier to compare Kubernetes objects against expected test data.
+- Add a `get_namespace_objects_for_test` method to the Kubernetes mock to retreive all objects (of any kind) in a namespace.
+- Add a mock for the `list_nodes` Kubernetes API, which returns data set by a call to the new `set_nodes_for_test` method.
+- Add optional rudimentary namespace tracking to the Kubernetes mock. Namespaces can be created, deleted (which deletes all objects in the namespace), read, and listed. Explicit namespace creation remains optional; if an object is created in a namespace and that namespace does not exist, one will be implicitly created by the mock.
+- Add support for namespaced events (the older core API, not the new events API) to the Kubernetes mock. Newly-created pods with the default initial status post an event by default; otherwise, events must be created by calling the mocked `create_namespaced_event` API. The `list_namespaced_event` API supports watches with timeouts.
+- Add rudimentary support for `NetworkPolicy`, `ResourceQuota`, and `Service` objects to the Kubernetes mock.
+
+### Other changes
+
+- The `safir.testing.kubernetes.MockKubernetesApi` mock now has rudimentary API documentation for the Kubernetes APIs that it supports.
 
 ## 3.8.0 (2023-03-15)
 

--- a/docs/user-guide/kubernetes.rst
+++ b/docs/user-guide/kubernetes.rst
@@ -50,21 +50,45 @@ Applications that want to run tests with the mock Kubernetes API should define a
    def mock_kubernetes() -> Iterator[MockKubernetesApi]:
        yield from patch_kubernetes()
 
-Then, when initializing Kubernetes, be sure not to import ``ApiClient``, ``CoreV1Api``, or ``CustomObjectsApi`` directly into a module.
+Then, when initializing Kubernetes, be sure not to import ``ApiClient``, ``CoreV1Api``, ``CustomObjectsApi``, or ``NetworkingV1Api`` directly into a module.
 Instead, use:
 
 .. code-block:: python
 
    from kubernetes_asyncio import client
 
-and then use ``client.ApiClient``, ``client.CoreV1Api``, and ``client.CustomObjectsApi``.
+and then use ``client.ApiClient``, ``client.CoreV1Api``, ``client.CustomObjectsApi``, or ``client.NetworkingV1Api``.
 This will ensure that the Kubernetes API is mocked properly.
 
 You can then use ``mock_kubernetes`` as a fixture.
-The resulting object supports a limited subset of the ``client.CoreV1Api`` and ``client.CustomObjectsApi`` method calls for creating, retrieving, modifying, and deleting objects.
+The resulting object supports a limited subset of the ``client.CoreV1Api``, ``client.CustomObjectsApi``, and ``client.NetworkingV1Api`` method calls for creating, retrieving, modifying, and deleting objects.
 The objects created by either the test or by the application code under test will be stored in memory inside the ``mock_kubernetes`` object.
 
-You can use the `~safir.testing.kubernetes.MockKubernetesApi.get_all_objects_for_test` method to retrieve all objects of a given kind, allowing comparisons against an expected list of objects.
+All objects will be modified to add the ``api_version`` and ``kind`` fields and, if appropriate, the ``metadata.namespace`` field before being stored, so those fields are optional, as with the normal Kubernetes API.
+If any of those fields are supplied, they must match the expected values for the API into which the object is passed.
+If they are not, the mock will raise `AssertionError`.
+
+Use the `~safir.testing.kubernetes.MockKubernetesApi.get_all_objects_for_test` method to retrieve all objects of a given kind, allowing comparisons against an expected list of objects.
+Use the `~safir.testing.kubernetes.MockKubernetesApi.get_namespace_objects_for_test` method to retrieve all objects (of whatever kind) in a given namespace.
+
+Limitations of the mock
+-----------------------
+
+Only a limited subset of the API is supported, and only the most commonly-used parameters of those APIs are supported.
+Expect to need to add additional APIs and parameters, either by subclassing this mock or by contributing them back to Safir, when testing a new application.
+
+Namespaces are only partially modeled.
+A namespace can be explicitly created with `~safir.testing.kubernetes.MockKubernetesApi.create_namespace`, in which case the provided ``V1Namespace`` object will be stored and returned by a subsequent `~safir.testing.kubernetes.MockKubernetesApi.read_namespace` or similar call.
+However, namespace creation is optional.
+If an object is created in a namespace, that namespace will magically come into existence, and a subsequent `~safir.testing.kubernetes.MockKubernetesApi.list_namespace` or `~safir.testing.kubernetes.MockKubernetesApi.read_namespace` call will return a synthetic namespace object.
+
+Most mock APIs do not support watches.
+The only exception is `~safir.testing.kubernetes.MockKubernetesApi.list_namespaced_event` (see :ref:`kubernetes-testing-events`).
+
+.. warning::
+
+   Objects stored with ``create_*`` or ``replace_*`` methods are stored directly in memory, not copied, and the same object is returned by ``read_*`` and ``list_*`` methods.
+   This means that modifying the object outside of the mock changes the data stored inside the mock.
 
 Testing error handling
 ----------------------
@@ -101,3 +125,62 @@ Here is a simplified example from `Gafaelfawr <https://gafaelfawr.lsst.io/>`__ t
                "severity": "error",
            },
        ]
+
+Testing pod status
+------------------
+
+By default, any pod object created with `~safir.testing.kubernetes.MockKubernetesApi.create_namespaced_pod` gets an initial status of ``Running`` and generates a pod started event for its namespace (see :ref:`kubernetes-testing-events`).
+This is done by modifying the pod object in place to add a status field.
+
+To start pods in a different status, set the ``initial_pod_phase`` attribute of the Kubernetes mock to some other value.
+If this is any value other than ``Running``, the pod startup event for the namespace will not be generated, so this also allows finer control of the events.
+
+.. _kubernetes-testing-events:
+
+Testing events
+--------------
+
+Currently, `~safir.testing.kubernetes.MockKubernetesApi.list_namespaced_event` is the only API that supports watches.
+Multiple watchers and timeouts are supported.
+The ``field_selector`` parameter is accepted, but is currently ignored.
+
+The only event that will be posted automatically by the mock is a pod started event when creating a pod with `~safir.testing.kubernetes.MockKubernetesApi.create_namespaced_pod`, provided that the ``initial_pod_phase`` attribute on the mock is set to its default value of ``Running``.
+All other events must be injected manually with `~safir.testing.kubernetes.MockKubernetesApi.create_namespaced_event`.
+
+Testing node state
+------------------
+
+By default, the `~safir.testing.kubernetes.MockKubernetesApi.list_node` API returns an empty ``V1NodeList``.
+A list of ``V1Node`` objects to return can be set by calling `~safir.testing.kubernetes.MockKubernetesApi.set_nodes_for_test`.
+
+Comparing objects
+-----------------
+
+A good pattern to use when testing Kubernetes controllers is to store the Kubernetes objects expected to be created by a test case as data files in the test suite, and then compare the objects created inside the mock to the stored data files.
+This, however, is complicated by the serialization format returned by the ``to_dict`` method of Kubernetes API objects.
+Every possible field is included in the serialization, so the stored data and the pytest-generated diffs are littered with meaningless `None` values.
+
+Safir provides the utility function `safir.testing.kubernetes.strip_none` to address this problem.
+It takes a data structure with arbitrary nested lists and dictionaries, such as the output from ``to_dict``, and deletes all the dictionary keys whose value is `None`.
+For Kubernetes objects, this is an equivalent but far more succinct canonical format, making comparisons easier.
+
+Here is an example of how this function could be used in a test:
+
+.. code-block:: python
+
+   import json
+   from pathlib import Path
+
+   import pytest
+   from safir.testing.kubernetes import MockKubernetesApi, strip_none
+
+
+   @pytest.mark.asyncio
+   async def test_controller(mock_kubernetes: MockKubernetesApi) -> None:
+       # Take various test actions that would create a pod.
+       pod = await mock_kubernetes.read_namespaced_pod("pod", "namespace")
+       data_path = Path(__name__).parent / "data" / "pod.json"
+       expected = json.loads(data_path.read_text())
+       assert strip_none(pod.to_dict()) == expected
+
+The data stored in :file:`tests/data/pod.json` can then contain only the interesting elements of the data model (the ones that are not `None`).

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -2,56 +2,147 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
+import json
 import os
 import re
-import uuid
-from collections.abc import Callable, Iterator
+from collections import defaultdict
+from collections.abc import AsyncIterator, Callable, Iterator
+from datetime import timedelta
 from typing import Any, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import (
     ApiException,
+    CoreV1Event,
+    CoreV1EventList,
     V1ConfigMap,
+    V1Namespace,
+    V1NamespaceList,
+    V1NetworkPolicy,
+    V1Node,
+    V1NodeList,
+    V1ObjectMeta,
+    V1ObjectReference,
     V1Pod,
     V1PodList,
     V1PodStatus,
+    V1ResourceQuota,
     V1Secret,
+    V1Service,
     V1Status,
 )
+
+from ..datetime import current_datetime
 
 __all__ = [
     "MockKubernetesApi",
     "patch_kubernetes",
+    "strip_none",
 ]
+
+
+def strip_none(model: dict[str, Any]) -> dict[str, Any]:
+    """Strip `None` values from a serialized Kubernetes object.
+
+    Comparing Kubernetes objects against serialized expected output is a bit
+    of a pain, since Kubernetes objects often contain tons of optional
+    parameters and the ``to_dict`` serialization includes every parameter.
+    The naive result is therefore tedious to read or understand.
+
+    This function works around this by taking a serialized Kubernetes object
+    and dropping all of the parameters that are set to `None`. The ``to_dict``
+    form of a Kubernetes object should be passed through it first before
+    comparing to the expected output.
+
+    Parmaters
+    ---------
+    model
+        Kubernetes model serialized with ``to_dict``.
+
+    Returns
+    -------
+    dict
+        Cleaned-up model with `None` parameters removed.
+    """
+    result = {}
+    for key, value in model.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            value = strip_none(value)
+        elif isinstance(value, list):
+            list_result = []
+            for item in value:
+                if isinstance(item, dict):
+                    item = strip_none(item)
+                list_result.append(item)
+            value = list_result
+        result[key] = value
+    return result
 
 
 class MockKubernetesApi:
     """Mock Kubernetes API for testing.
 
-    This object simulates (with almost everything left out) the ``CoreV1Api``
-    and ``CustomObjectApi`` client objects while keeping simple internal
-    state.  It is intended to be used as a mock inside tests.
+    This object simulates (with almost everything left out) the ``CoreV1Api``,
+    ``CustomObjectApi``, and ``NetworkingV1Api`` client objects while keeping
+    simple internal state. It is intended to be used as a mock inside tests.
 
     Methods ending with ``_for_test`` are outside of the API and are intended
     for use by the test suite.
 
-    If ``error_callback`` is set to a callable, it will be called with the
-    method name and any arguments whenever any Kubernetes API method is called
-    and before it takes any action.  This can be used to inject exceptions for
-    test purposes.
+    This mock does not enforce namespace creation before creating objects in a
+    namespace. Creating an object in a namespace will implicitly create that
+    namespace if it doesn't exist. However, it will not store a
+    ``V1Namespace`` object, so to verify that a namespace was properly created
+    (although not the order of creation), retrieve all the objects in the
+    namespace with `get_namespace_objects_for_test` and one of them will be
+    the ``V1Namespace`` object.
+
+    Objects stored with ``create_*`` or ``replace_*`` methods are **NOT**
+    copied. The object provided will be stored, so changing that object will
+    change the object returned by subsequent API calls. Likewise, the object
+    returned by ``read_*`` calls will be the same object stored in the mock,
+    and changing it will change the mock's data. (Sometimes this is the
+    desired behavior, sometimes it isn't; we had to pick one and this is the
+    approach we picked.)
+
+    Most APIs do not support watches. The only current exception is
+    `list_namespaced_event`.
+
+    Attributes
+    ----------
+    initial_pod_phase
+        String value to set the status of pods to when created. If this is set
+        to ``Running`` (the default), a pod start event will also be
+        generated when the pod is created.
+    error_callback
+        If set, called with the method name and any arguments whenever any
+        Kubernetes API method is called and before it takes any acttion. This
+        can be used for fault injection for testing purposes.
 
     Notes
     -----
-    This class is normally not instantiated directly.  Instead, call the
-    `patch_kubernetes` function from a fixture to set up the mock.
+    This class is normally not instantiated directly. Instead, call the
+    `patch_kubernetes` function from a fixture to set up the mock. This is
+    also why it is configurable by setting attributes rather than constructor
+    arguments; the individual test usually doesn't have control of the
+    constructor.
     """
 
     def __init__(self) -> None:
         self.error_callback: Optional[Callable[..., None]] = None
-        self.objects: dict[str, dict[str, dict[str, Any]]] = {}
-        self.custom_kinds: dict[str, str] = {}
+        self.initial_pod_phase = "Running"
+
+        self._custom_kinds: dict[str, str] = {}
+        self._events: defaultdict[str, list[CoreV1Event]] = defaultdict(list)
+        self._new_events: defaultdict[str, asyncio.Event]
+        self._new_events = defaultdict(asyncio.Event)
+        self._nodes = V1NodeList(items=[])
+        self._objects: dict[str, dict[str, dict[str, Any]]] = {}
 
     def get_all_objects_for_test(self, kind: str) -> list[Any]:
         """Return all objects of a given kind sorted by namespace and name.
@@ -59,7 +150,7 @@ class MockKubernetesApi:
         Parameters
         ----------
         kind
-            The Kubernetes kind, such as ``Secret`` or ``Pod``.  This is
+            The Kubernetes kind, such as ``Secret`` or ``Pod``. This is
             case-sensitive.
 
         Returns
@@ -68,54 +159,48 @@ class MockKubernetesApi:
             All objects of that kind found in the mock, sorted by namespace
             and then name.
         """
-        key = self.custom_kinds[kind] if kind in self.custom_kinds else kind
+        key = self._custom_kinds[kind] if kind in self._custom_kinds else kind
         results = []
-        for namespace in sorted(self.objects.keys()):
-            if key not in self.objects[namespace]:
+        for namespace in sorted(self._objects.keys()):
+            if key not in self._objects[namespace]:
                 continue
-            for name in sorted(self.objects[namespace][key].keys()):
-                results.append(self.objects[namespace][key][name])
+            for name, obj in sorted(self._objects[namespace][key].items()):
+                results.append(obj)
         return results
 
-    def _maybe_error(self, method: str, *args: Any) -> None:
-        """Helper function to avoid using class method call syntax."""
-        if self.error_callback:
-            callback = self.error_callback
-            callback(method, *args)
+    def get_namespace_objects_for_test(self, namespace: str) -> list[Any]:
+        """Returns all objects in the given namespace.
 
-    def _get_object(self, namespace: str, key: str, name: str) -> Any:
-        if namespace not in self.objects:
-            reason = f"{namespace}/{name} not found"
-            raise ApiException(status=404, reason=reason)
-        if name not in self.objects[namespace].get(key, {}):
-            reason = f"{namespace}/{name} not found"
-            raise ApiException(status=404, reason=reason)
-        return self.objects[namespace][key][name]
+        Parameters
+        ----------
+        namespace
+            Name of the namespace.
 
-    def _store_object(
-        self,
-        namespace: str,
-        key: str,
-        name: str,
-        obj: Any,
-        replace: bool = False,
-    ) -> None:
-        if replace:
-            self._get_object(namespace, key, name)
-        else:
-            if namespace not in self.objects:
-                self.objects[namespace] = {}
-            if key not in self.objects[namespace]:
-                self.objects[namespace][key] = {}
-            if name in self.objects[namespace][key]:
-                msg = f"{namespace}/{name} exists"
-                raise ApiException(status=500, reason=msg)
-        self.objects[namespace][key][name] = obj
+        Returns
+        -------
+        list of Any
+            All objects found in that namespace, sorted by kind and then name.
+            Due to how objects are stored in the mock, we can't distinguish
+            between a missing namespace and a namespace with no objects. In
+            both cases, the empty list is returned.
+        """
+        if namespace not in self._objects:
+            return []
+        result = []
+        for kind in sorted(self._objects[namespace].keys()):
+            for _, body in sorted(self._objects[namespace][kind].items()):
+                result.append(body)
+        return result
 
-    def _delete_object(self, namespace: str, key: str, name: str) -> V1Status:
-        self._get_object(namespace, key, name)
-        del self.objects[namespace][key][name]
-        return V1Status(code=200)
+    def set_nodes_for_test(self, nodes: list[V1Node]) -> None:
+        """Set the node structures that will be returned by `list_node`.
+
+        Parameters
+        ----------
+        nodes
+            New node list to return.
+        """
+        self._nodes = V1NodeList(items=nodes)
 
     # CUSTOM OBJECT API
 
@@ -127,6 +212,26 @@ class MockKubernetesApi:
         plural: str,
         body: dict[str, Any],
     ) -> None:
+        """Create a new custom namespaced object.
+
+        Parameters
+        ----------
+        group
+            API group for this custom object.
+        version
+            API version for this custom object.
+        namespace
+            Namespace in which to create the object.
+        plural
+            API plural for this custom object.
+        body
+            Custom object to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
         self._maybe_error(
             "create_namespaced_custom_object",
             group,
@@ -135,15 +240,15 @@ class MockKubernetesApi:
             plural,
             body,
         )
+        api_version = body.get("api_version", body["apiVersion"])
+        assert api_version == f"{group}/{version}"
         key = f"{group}/{version}/{plural}"
-        if body["kind"] in self.custom_kinds:
-            assert key == self.custom_kinds[body["kind"]]
+        if body["kind"] in self._custom_kinds:
+            assert key == self._custom_kinds[body["kind"]]
         else:
-            self.custom_kinds[body["kind"]] = key
+            self._custom_kinds[body["kind"]] = key
         assert namespace == body["metadata"]["namespace"]
-        obj = copy.deepcopy(body)
-        obj["metadata"]["uid"] = str(uuid.uuid4())
-        self._store_object(namespace, key, body["metadata"]["name"], obj)
+        self._store_object(namespace, key, body["metadata"]["name"], body)
 
     async def get_namespaced_custom_object(
         self,
@@ -153,6 +258,31 @@ class MockKubernetesApi:
         plural: str,
         name: str,
     ) -> dict[str, Any]:
+        """Retrieve a namespaced custom object.
+
+        Parameters
+        ----------
+        group
+            API group for this custom object.
+        version
+            API version for this custom object.
+        namespace
+            Namespace in which to create the object.
+        plural
+            API plural for this custom object.
+        name
+            Name of the object to retrieve.
+
+        Returns
+        -------
+        dict of Any
+            Body of the custom object.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the object does not exist.
+        """
         self._maybe_error(
             "get_namespaced_custom_object",
             group,
@@ -166,12 +296,29 @@ class MockKubernetesApi:
     async def list_cluster_custom_object(
         self, group: str, version: str, plural: str
     ) -> dict[str, list[dict[str, Any]]]:
+        """List all custom objects in the cluster.
+
+        Parameters
+        ----------
+        group
+            API group for this custom object.
+        version
+            API version for this custom object.
+        plural
+            API plural for this custom object.
+
+        Returns
+        -------
+        dict
+            Dictionary with one key, ``items``, whose value is a list of all
+            the specified custom objects stored in the cluster.
+        """
         self._maybe_error("list_cluster_custom_object", group, version, plural)
         key = f"{group}/{version}/{plural}"
         results = []
-        for namespace in self.objects.keys():
-            for name in self.objects[namespace].get(key, {}).keys():
-                results.append(self.objects[namespace][key][name])
+        for namespace in self._objects.keys():
+            for name, obj in self._objects[namespace].get(key, {}).items():
+                results.append(obj)
         return {"items": results}
 
     async def patch_namespaced_custom_object_status(
@@ -183,6 +330,36 @@ class MockKubernetesApi:
         name: str,
         body: list[dict[str, Any]],
     ) -> dict[str, Any]:
+        """Patch the status of a namespaced custom object.
+
+        Parameters
+        ----------
+        group
+            API group for this custom object.
+        version
+            API version for this custom object.
+        namespace
+            Namespace in which to create the object.
+        plural
+            API plural for this custom object.
+        name
+            Name of the object to retrieve.
+        body
+            Body of the patch. The only patch supported is one with ``op`` of
+            ``replace`` and ``path`` of ``/status``.
+
+        Returns
+        -------
+        dict of Any
+            Modified body of the custom object.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the object does not exist.
+        AssertionError
+            Raised if any other type of patch is provided.
+        """
         self._maybe_error(
             "patch_namespaced_custom_object_status",
             group,
@@ -209,6 +386,26 @@ class MockKubernetesApi:
         name: str,
         body: dict[str, Any],
     ) -> None:
+        """Replace a custom namespaced object.
+
+        Parameters
+        ----------
+        group
+            API group for this custom object.
+        version
+            API version for this custom object.
+        namespace
+            Namespace in which to create the object.
+        plural
+            API plural for this custom object.
+        body
+            New contents of custom object.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 if the object does not exist.
+        """
         self._maybe_error(
             "replace_namespaced_custom_object",
             group,
@@ -218,69 +415,542 @@ class MockKubernetesApi:
             name,
             body,
         )
+        api_version = body.get("api_version", body["apiVersion"])
+        assert api_version == f"{group}/{version}"
         key = f"{group}/{version}/{plural}"
-        assert key == self.custom_kinds[body["kind"]]
+        assert key == self._custom_kinds[body["kind"]]
         assert namespace == body["metadata"]["namespace"]
         self._store_object(namespace, key, name, body, replace=True)
 
     # CONFIGMAP API
 
     async def create_namespaced_config_map(
-        self, namespace: str, config_map: V1ConfigMap
+        self, namespace: str, body: V1ConfigMap
     ) -> None:
-        self._maybe_error(
-            "create_namespaced_config_map", namespace, config_map
-        )
-        assert namespace == config_map.metadata.namespace
-        name = config_map.metadata.name
-        self._store_object(namespace, "ConfigMap", name, config_map)
+        """Create a ``ConfigMap`` object.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to store the object.
+        body
+            Object to store.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
+        self._maybe_error("create_namespaced_config_map", namespace, body)
+        self._update_metadata(body, "v1", "ConfigMap", namespace)
+        name = body.metadata.name
+        self._store_object(namespace, "ConfigMap", name, body)
 
     async def delete_namespaced_config_map(
         self, name: str, namespace: str
     ) -> V1Status:
+        """Delete a ``ConfigMap`` object.
+
+        Parameters
+        ----------
+        name
+            Name of object.
+        namespace
+            Namespace of object.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Status
+            Success status if object was deleted.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the object does not exist.
+        """
         self._maybe_error("delete_namespaced_config_map", name, namespace)
         return self._delete_object(namespace, "ConfigMap", name)
 
+    # EVENTS API
+
+    async def create_namespaced_event(
+        self, namespace: str, body: CoreV1Event
+    ) -> None:
+        """Store a new namespaced event.
+
+        This uses the old core event API, not the new Events API.
+
+        Parameters
+        ----------
+        namespace
+            Namespace of the event.
+        body
+            New event to store.
+        """
+        self._maybe_error("create_namespaced_event", namespace, body)
+        self._update_metadata(body, "v1", "Event", namespace)
+        body.metadata.resource_version = str(len(self._events[namespace]))
+        self._events[namespace].append(body)
+        self._new_events[namespace].set()
+
+    async def list_namespaced_event(
+        self,
+        namespace: str,
+        *,
+        field_selector: Optional[str] = None,
+        resource_version: str = "0",
+        timeout_seconds: Optional[int] = None,
+        watch: bool = False,
+        _preload_content: bool = True,
+        _request_timeout: Optional[int] = None,
+    ) -> CoreV1EventList | Mock:
+        """List namespaced events.
+
+        This uses the old core event API, not the new Events API. It does
+        support watches.
+
+        Parameters
+        ----------
+        namespace
+            Namespace to watch for events.
+        field_selector
+            Which events to retrieve when performing a watch. Currently, this
+            is ignored.
+        resource_version
+            Where to start in the event stream when performing a watch.
+        timeout_seconds
+            How long to return events for before exiting when performing a
+            watch.
+        watch
+            Whether to act as a watch.
+        _preload_content
+            Verified to be `False` when performing a watch.
+        _request_timeout
+            Ignored, accepted for compatibility with the watch API.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.CoreV1EventList or unittest.mock.Mock
+            List of events, when not called as a watch. If called as a watch,
+            returns a mock ``aiohttp.Response`` with a ``readline`` method
+            that yields the events.
+        """
+        self._maybe_error("list_namespaced_event", namespace)
+        if not watch:
+            return CoreV1EventList(items=self._events[namespace])
+
+        # All watches must not preload content since we're returning raw JSON.
+        # This is done by the Kubernetes API Watch object.
+        assert not _preload_content
+
+        # When the timeout has expired.
+        timeout = None
+        if timeout_seconds is not None:
+            timeout = current_datetime() + timedelta(seconds=timeout_seconds)
+
+        # Returns all available events for this namespace, and then waits for
+        # new events and returns them up to the timeout.
+        async def next_event() -> AsyncIterator[bytes]:
+            position = int(resource_version)
+            while True:
+                for event in self._events[namespace][position:]:
+                    raw = {"type": "ADDED", "object": event.to_dict()}
+                    yield json.dumps(raw).encode()
+                    position += 1
+                wait_event = self._new_events[namespace]
+                if not timeout:
+                    await wait_event.wait()
+                else:
+                    now = current_datetime()
+                    timeout_left = (timeout - now).total_seconds()
+                    if timeout_left < 0:
+                        yield b""
+                        return
+                    try:
+                        await asyncio.wait_for(wait_event.wait(), timeout_left)
+                    except TimeoutError:
+                        yield b""
+                        return
+
+        event_generator = next_event()
+
+        async def readline() -> bytes:
+            return await event_generator.__anext__()
+
+        # To support the watch interface, we have to simulate a streaming
+        # aiohttp response. Thankfully, the watch only uses a minimal
+        # interface, so we can get away with a simple mock.
+        response = Mock()
+        response.content.readline = AsyncMock()
+        response.content.readline.side_effect = readline
+        return response
+
+    # NAMESPACE API
+
+    async def create_namespace(self, body: V1Namespace) -> None:
+        """Create a namespace.
+
+        The mock doesn't truly track namespaces since it autocreates them when
+        an object is created in that namespace (maybe that behavior should be
+        optional). However, this method detects conflicts and stores the
+        ``V1Namespace`` object so that it can be verified.
+
+        Parameters
+        ----------
+        body
+            Namespace to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the namespace already exists.
+        """
+        self._maybe_error("create_namespace", body)
+        self._update_metadata(body, "v1", "Namespace", None)
+        name = body.metadata.name
+        if name in self._objects:
+            msg = f"Namespace {name} already exists"
+            raise ApiException(status=409, reason=msg)
+        self._store_object(name, "Namespace", name, body)
+
+    async def delete_namespace(self, name: str) -> None:
+        """Delete a namespace.
+
+        This also immediately removes all objects in the namespace.
+
+        Parameters
+        ----------
+        name
+            Namespace to delete.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the namespace does not exist.
+        """
+        self._maybe_error("delete_namespace")
+        if name not in self._objects:
+            raise ApiException(status=404, reason=f"{name} not found")
+        del self._objects[name]
+
+    async def read_namespace(self, name: str) -> V1Namespace:
+        """Return the namespace object for a namespace.
+
+        Parameters
+        ----------
+        name
+            Name of namespace to retrieve.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Namespace
+            Corresponding namespace object. If `create_namespace` has
+            been called, will return the stored object. Otherwise, returns a
+            synthesized ``V1Namespace`` object if the namespace has been
+            implicitly created.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the namespace does not exist.
+        """
+        self._maybe_error("read_namespace", name)
+        if name not in self._objects:
+            msg = f"Namespace {name} not found"
+            raise ApiException(status=404, reason=msg)
+        try:
+            return self._get_object(name, "Namespace", name)
+        except ApiException:
+            return V1Namespace(metadata=V1ObjectMeta(name=name))
+
+    async def list_namespace(self) -> V1NamespaceList:
+        """List known namespaces.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1NamespaceList
+            All namespaces, whether implicitly created or not. These will be
+            the actual ``V1Namespace`` objects if one was stored, otherwise
+            synthesized namespace objects.
+        """
+        self._maybe_error("list_namespace")
+        namespaces = []
+        for namespace in self._objects:
+            namespaces.append(await self.read_namespace(namespace))
+        return V1NamespaceList(items=namespaces)
+
+    # NETWORKPOLICY API
+
+    async def create_namespaced_network_policy(
+        self, namespace: str, body: V1NetworkPolicy
+    ) -> None:
+        """Create a network policy object.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to create the object.
+        body
+            Object to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
+        self._maybe_error("create_namespaced_network_policy", namespace, body)
+        self._update_metadata(
+            body, "networking.k8s.io/v1", "NetworkPolicy", namespace
+        )
+        name = body.metadata.name
+        self._store_object(namespace, "NetworkPolicy", name, body)
+
+    # NODE API
+
+    async def list_node(self) -> V1NodeList:
+        """List node information.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1NodeList
+            The node information previouslyl stored with `set_nodes_for_test`,
+            if any.
+        """
+        self._maybe_error("list_node")
+        return self._nodes
+
     # POD API
 
-    async def create_namespaced_pod(self, namespace: str, pod: V1Pod) -> None:
-        self._maybe_error("create_namespaced_pod", namespace, pod)
-        assert namespace == pod.metadata.namespace
-        name = pod.metadata.name
-        pod.status = V1PodStatus(phase="Running")
-        self._store_object(namespace, "Pod", name, pod)
+    async def create_namespaced_pod(self, namespace: str, body: V1Pod) -> None:
+        """Create a pod object.
+
+        If ``initial_pod_phase`` on the mock Kubernetes object is set to
+        ``Running``, set the state to ``Running`` and generate a startup
+        event. Otherwise, the status is set to whatever ``initial_pod_phase``
+        is set to, and no event is generated.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to create the pod.
+        body
+            Pod specification.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the pod already exists.
+        """
+        self._maybe_error("create_namespaced_pod", namespace, body)
+        self._update_metadata(body, "v1", "Pod", namespace)
+        body.status = V1PodStatus(phase=self.initial_pod_phase)
+        self._store_object(namespace, "Pod", body.metadata.name, body)
+        if self.initial_pod_phase == "Running":
+            event = CoreV1Event(
+                metadata=V1ObjectMeta(
+                    name=f"{body.metadata.name}-start", namespace=namespace
+                ),
+                message=f"Pod {body.metadata.name} started",
+                involved_object=V1ObjectReference(
+                    kind="Pod", name=body.metadata.name, namespace=namespace
+                ),
+            )
+            await self.create_namespaced_event(namespace, event)
 
     async def delete_namespaced_pod(
         self, name: str, namespace: str
     ) -> V1Status:
+        """Delete a pod object.
+
+        Parameters
+        ----------
+        name
+            Name of pod to delete.
+        namespace
+            Namespace of pod to delete.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Status
+            Success status.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the pod was not found.
+        """
         self._maybe_error("delete_namespaced_pod", name, namespace)
         return self._delete_object(namespace, "Pod", name)
 
     async def list_namespaced_pod(
-        self, namespace: str, *, field_selector: str
+        self, namespace: str, *, field_selector: Optional[str] = None
     ) -> V1PodList:
+        """List pod objects in a namespace.
+
+        Parameters
+        ----------
+        namespace
+            Namespace of pods to list.
+        field_selector
+            Only ``metadata.name=...`` is supported. It is parsed to find the
+            pod name and only pods matching that name will be returned.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1PodList
+            List of pods in that namespace.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the namespace does not exist.
+        AssertionError
+            Some other ``field_selector`` was provided.
+        """
         self._maybe_error("list_namespaced_pod", namespace, field_selector)
-        match = re.match(r"metadata\.name=(.*)$", field_selector)
-        assert match and match.group(1)
-        pod = self._get_object(namespace, "Pod", match.group(1))
-        return V1PodList(kind="Pod", items=[pod])
+        if namespace not in self._objects:
+            msg = f"Namespace {namespace} not found"
+            raise ApiException(status=404, reason=msg)
+        if field_selector:
+            match = re.match(r"metadata\.name=(.*)$", field_selector)
+            assert match and match.group(1)
+            try:
+                pod = self._get_object(namespace, "Pod", match.group(1))
+                return V1PodList(kind="Pod", items=[pod])
+            except ApiException:
+                return V1PodList(kind="Pod", items=[])
+        else:
+            pods = []
+            for obj in self._objects[namespace]["Pod"].values():
+                pods.append(obj)
+            return V1PodList(kind="Pod", items=pods)
 
     async def read_namespaced_pod(self, name: str, namespace: str) -> V1Pod:
+        """Read a pod object.
+
+        Parameters
+        ----------
+        name
+            Name of the pod.
+        namespace
+            Namespace of the pod.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Pod
+            Pod object.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the pod was not found.
+        """
         self._maybe_error("read_namespaced_pod", name, namespace)
         return self._get_object(namespace, "Pod", name)
+
+    async def read_namespaced_pod_status(
+        self, name: str, namespace: str
+    ) -> V1Pod:
+        """Read the status of a pod.
+
+        Parameters
+        ----------
+        name
+            Name of the pod.
+        namespace
+            Namespace of the pod.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Pod
+            Pod object. The Kubernetes API returns a ``V1Pod`` rather than, as
+            expected, a ``V1PodStatus``. Presumably the acutal API populates
+            only the status portion, but we return the whole pod for testing
+            purposes since it shouldn't matter.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the pod was not found.
+        """
+        self._maybe_error("read_namespaced_pod_status", name, namespace)
+        return self._get_object(namespace, "Pod", name)
+
+    # RESOURCEQUOTA API
+
+    async def create_namespaced_resource_quota(
+        self, namespace: str, body: V1ResourceQuota
+    ) -> None:
+        """Create a resource quota object.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to create the object.
+        body
+            Object to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
+        self._maybe_error("create_namespaced_resource_quota", namespace, body)
+        self._update_metadata(body, "v1", "ResourceQuota", namespace)
+        name = body.metadata.name
+        self._store_object(namespace, "ResourceQuota", name, body)
 
     # SECRETS API
 
     async def create_namespaced_secret(
-        self, namespace: str, secret: V1Secret
+        self, namespace: str, body: V1Secret
     ) -> None:
-        self._maybe_error("create_namespaced_secret", namespace, secret)
-        assert namespace == secret.metadata.namespace
-        self._store_object(namespace, "Secret", secret.metadata.name, secret)
+        """Create a secret object.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to create the object.
+        body
+            Object to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
+        self._maybe_error("create_namespaced_secret", namespace, body)
+        self._update_metadata(body, "v1", "Secret", namespace)
+        self._store_object(namespace, "Secret", body.metadata.name, body)
 
     async def patch_namespaced_secret(
         self, name: str, namespace: str, body: list[dict[str, Any]]
     ) -> V1Secret:
+        """Patch a secret object.
+
+        Parameters
+        ----------
+        name
+            Name of secret object.
+        namespace
+            Namespace of secret object.
+        body
+            Patches to apply. Only patches with ``op`` of ``replace`` are
+            supported, and only with ``path`` of either
+            ``/metadata/annotations`` or ``/metadata/labels``.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Secret
+            Patched secret object.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the secret does not exist.
+        AssertionError
+            Raised if any other type of patch was provided.
+        """
         self._maybe_error("patch_namespaced_secret", name, namespace)
         obj = copy.deepcopy(self._get_object(namespace, "Secret", name))
         for change in body:
@@ -296,14 +966,208 @@ class MockKubernetesApi:
     async def read_namespaced_secret(
         self, name: str, namespace: str
     ) -> V1Secret:
+        """Read a secret.
+
+        Parameters
+        ----------
+        name
+            Name of secret.
+        namespace
+            Namespace of secret.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Secret
+            Requested secret.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the secret does not exist.
+        """
         self._maybe_error("read_namespaced_secret", name, namespace)
         return self._get_object(namespace, "Secret", name)
 
     async def replace_namespaced_secret(
-        self, name: str, namespace: str, secret: V1Secret
+        self, name: str, namespace: str, body: V1Secret
     ) -> None:
-        self._maybe_error("replace_namespaced_secret", namespace, secret)
-        self._store_object(namespace, "Secret", name, secret, replace=True)
+        """Replace a secret.
+
+        Parameters
+        ----------
+        name
+            Name of secret.
+        namespace
+            Namespace of secret.
+        body
+            New body of secret.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the secret does not exist.
+        """
+        self._maybe_error("replace_namespaced_secret", namespace, body)
+        self._store_object(namespace, "Secret", name, body, replace=True)
+
+    # SERVICE API
+
+    async def create_namespaced_service(
+        self, namespace: str, body: V1Service
+    ) -> None:
+        """Create a service object.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to create the object.
+        body
+            Object to create.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 409 status if the object already exists.
+        """
+        self._maybe_error("create_namespaced_service", namespace, body)
+        self._update_metadata(body, "v1", "Service", namespace)
+        self._store_object(namespace, "Service", body.metadata.name, body)
+
+    # Internal helper functions.
+
+    def _delete_object(self, namespace: str, key: str, name: str) -> V1Status:
+        """Delete an object from internal data structures.
+
+        Returns
+        -------
+        kubernetes_asyncio.client.V1Status
+            200 return status if the object was found and deleted.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with a 404 status if the object is not found.
+        """
+        # Called for the side effect of raising an exception if the object is
+        # not found.
+        self._get_object(namespace, key, name)
+
+        del self._objects[namespace][key][name]
+        return V1Status(code=200)
+
+    def _get_object(self, namespace: str, key: str, name: str) -> Any:
+        """Retrieve an object from internal data structures.
+
+        Returns
+        -------
+        Any
+            Object if found.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with a 404 status if the object is not found.
+        """
+        if namespace not in self._objects:
+            reason = f"{namespace}/{name} not found"
+            raise ApiException(status=404, reason=reason)
+        if name not in self._objects[namespace].get(key, {}):
+            reason = f"{namespace}/{name} not found"
+            raise ApiException(status=404, reason=reason)
+        return self._objects[namespace][key][name]
+
+    def _maybe_error(self, method: str, *args: Any) -> None:
+        """Helper function to avoid using class method call syntax."""
+        if self.error_callback:
+            callback = self.error_callback
+            callback(method, *args)
+
+    def _store_object(
+        self,
+        namespace: str,
+        key: str,
+        name: str,
+        obj: Any,
+        replace: bool = False,
+    ) -> None:
+        """Store an object in internal data structures.
+
+        Parameters
+        ----------
+        namespace
+            Namespace in which to store the object.
+        key
+            Key under which to store the object (generally the kind).
+        name
+            Name of object.
+        obj
+            Object to store.
+        replace
+            If `True`, the object must already exist, to mirror the Kubernetes
+            replace semantices. If `False`, a conflict error is raised if the
+            object already exists.
+
+        Raises
+        ------
+        kubernetes_asyncio.client.ApiException
+            Raised with 404 status if the object does not exist and ``replace``
+            was `True`, and with 409 status if the object does exist and
+            ``replace`` was `False`.
+        """
+        if replace:
+            self._get_object(namespace, key, name)
+        else:
+            if namespace not in self._objects:
+                self._objects[namespace] = {}
+            if key not in self._objects[namespace]:
+                self._objects[namespace][key] = {}
+            if name in self._objects[namespace][key]:
+                msg = f"{namespace}/{name} exists"
+                raise ApiException(status=409, reason=msg)
+        self._objects[namespace][key][name] = obj
+
+    def _update_metadata(
+        self, body: Any, api_version: str, kind: str, namespace: str | None
+    ) -> None:
+        """Check and potentially update the metadata of a stored object.
+
+        The Kubernetes API allows the ``api_version``, ``kind``, and
+        ``metadata.namespace`` attributes to be omitted since they can be
+        determined from the method called or its parameters. Implement the
+        same logic, but if they are provided in the object, require that they
+        be correct (match the parameters inferred from the call).
+
+        Parameters
+        ----------
+        body
+            Object being stored. Updated in place with namespace, kind, and
+            API version information.
+        api_version
+            Expected API version of object.
+        kind
+            Expected kind of object.
+        namespace
+            Namespace in which it is being stored, or `None` for objects that
+            are not namespaced.
+
+        Raises
+        ------
+        AssertionError
+            Raised if the namespace, kind, or API version was provided but
+            didn't match the expected value.
+        """
+        if body.api_version:
+            assert body.api_version == api_version
+        else:
+            body.api_version = api_version
+        if body.kind:
+            assert body.kind == kind
+        else:
+            body.kind = kind
+        if body.metadata.namespace:
+            assert body.metadata.namespace == namespace
+        else:
+            body.metadata.namespace = namespace
 
 
 def patch_kubernetes() -> Iterator[MockKubernetesApi]:
@@ -349,7 +1213,7 @@ def patch_kubernetes() -> Iterator[MockKubernetesApi]:
     mock_api = MockKubernetesApi()
     with patch.object(config, "load_incluster_config"):
         patchers = []
-        for api in ("CoreV1Api", "CustomObjectsApi"):
+        for api in ("CoreV1Api", "CustomObjectsApi", "NetworkingV1Api"):
             patcher = patch.object(client, api)
             mock_class = patcher.start()
             mock_class.return_value = mock_api

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import redis.asyncio as redis
 import respx
 
 from safir.testing.gcs import MockStorageClient, patch_google_storage
+from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 
 
@@ -19,6 +20,11 @@ def mock_gcs() -> Iterator[MockStorageClient]:
     yield from patch_google_storage(
         expected_expiration=timedelta(hours=1), bucket_name="some-bucket"
     )
+
+
+@pytest.fixture
+def mock_kubernetes() -> Iterator[MockKubernetesApi]:
+    yield from patch_kubernetes()
 
 
 @pytest.fixture

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -1,0 +1,15 @@
+"""Tests for Kubernetes utilities."""
+
+from __future__ import annotations
+
+import pytest
+from kubernetes_asyncio import config
+
+from safir.kubernetes import initialize_kubernetes
+from safir.testing.kubernetes import MockKubernetesApi
+
+
+@pytest.mark.asyncio
+async def test_initialize(mock_kubernetes: MockKubernetesApi) -> None:
+    await initialize_kubernetes()
+    assert config.load_incluster_config.call_count == 1

--- a/tests/testing/conftest.py
+++ b/tests/testing/conftest.py
@@ -1,8 +1,4 @@
-"""Fixtures for tests of the testing support infrastructure.
-
-Defines fixtures similar to what users of the Safir library should define so
-that they can be exercised in tests of the test support infrastructure.
-"""
+"""Fixtures for tests of the testing support infrastructure."""
 
 from __future__ import annotations
 
@@ -13,12 +9,6 @@ from pathlib import Path
 import pytest
 
 from safir.testing.gcs import MockStorageClient, patch_google_storage
-from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
-
-
-@pytest.fixture
-def mock_kubernetes() -> Iterator[MockKubernetesApi]:
-    yield from patch_kubernetes()
 
 
 @pytest.fixture


### PR DESCRIPTION
In order to test the new Nublado lab controller, we had to make multiple improvements to the Kubernetes mock and fix a few places where it was incompatible with the kubernetes_asyncio API. Merge those changes back into the Safir version and add additional documentation.

This also adds a new strip_none utility function for removing None key values from possibly-nested complex data structures, which makes it easier to compare Kubernetes objects in serialized form.

Add basic API documentation to all the supported methods of the Kubernetes mock. For reasons that I don't understand, this requires fully-qualified types to avoid Sphinx warnings, even though unqualified types have been working everywhere else.