### PR TITLE
DM-38660: Change validate_exactly_one_of to a root validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ X.Y.Z (YYYY-MM-DD)
 ### Backwards-incompatible changes
 
 - Safir now requires a minimum Python version of 3.11.
+- `safir.pydantic.validate_exactly_one_of` is now a Pydantic root validator instead of an individual field validator, which simplifies how it should be called.
 - Custom Kubernetes objects are no longer copied before being stored in the Kubernetes mock by `create_namespaced_custom_object`, and no longer automatically get a `metadata.uid` value. This brings handling of custom objects in line with the behavior of other mocked `create_*` and `replace_*` APIs.
 - All objects stored in the Kubernetes mock will be modified to set `api_version`, `kind`, and (where appropriate) `namespace`. If any of those values are set in the object, they are checked for correctness and rejected with `AssertionError` if they don't match the API call and its parameters.
 - The mocked `create_*` Kubernetes APIs now use the name `body` for the parameter containing the API object, instead of using some other name specific to the kind of object. This fixes compatibility with the Python Kubernetes API that this class is mocking.

--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -86,7 +86,7 @@ The intent here is that only one of those two configurations will be present: ei
 However, Pydantic has no native way to express that, and the above model will accept input where neither or both of those attributes are set.
 
 Safir provides a function, `~safir.pydantic.validate_exactly_one_of`, designed for this case.
-It takes a list of fields, of which exactly one must be set, and builds a validation function that checks this property of the model.
+It takes a list of fields, of which exactly one must be set, and builds a root validator function that checks this property of the model.
 
 So, in the above example, the full class would be:
 
@@ -96,12 +96,9 @@ So, in the above example, the full class would be:
        docker: Optional[DockerConfig] = None
        ghcr: Optional[GHCRConfig] = None
 
-       _validate_type = validator("ghcr", always=True, allow_reuse=True)(
+       _validate_type = root_validator(allow_reuse=True)(
            validate_exactly_one_of("docker", "ghcr")
        )
 
 Note the syntax, which is a little odd since it is calling a decorator on the results of a function builder.
-
-The argument to `~pydantic.validator` must always be the last of the possible attributes that may be set, ensuring that any other attributes have been seen when the validator runs.
-``always=True`` must be set to ensure the validator runs regardless of which attribute is set.
 ``allow_reuse=True`` must be set due to limitations in Pydantic.

--- a/src/safir/pydantic.py
+++ b/src/safir/pydantic.py
@@ -215,7 +215,7 @@ class CamelCaseModel(BaseModel):
 
 def validate_exactly_one_of(
     *settings: str,
-) -> Callable[[Any, dict[str, Any]], Any]:
+) -> Callable[[type, dict[str, Any]], dict[str, Any]]:
     """Generate a validator imposing a one and only one constraint.
 
     Sometimes, models have a set of attributes of which one and only one may
@@ -233,7 +233,7 @@ def validate_exactly_one_of(
     Returns
     -------
     Callable
-        The validator.
+        The root validator.
 
     Examples
     --------
@@ -246,7 +246,7 @@ def validate_exactly_one_of(
            bar: Optional[str] = None
            baz: Optional[str] = None
 
-           _validate_options = validator("baz", always=True, allow_reuse=True)(
+           _validate_options = root_validator(allow_reuse=True)(
                validate_exactly_one_of("foo", "bar", "baz")
            )
 
@@ -263,8 +263,8 @@ def validate_exactly_one_of(
     else:
         options = ", ".join(settings[:-1]) + ", and " + settings[-1]
 
-    def validator(v: Any, values: dict[str, Any]) -> Any:
-        seen = v is not None
+    def validator(cls: type, values: dict[str, Any]) -> dict[str, Any]:
+        seen = False
         for setting in settings:
             if setting in values and values[setting] is not None:
                 if seen:
@@ -272,6 +272,6 @@ def validate_exactly_one_of(
                 seen = True
         if not seen:
             raise ValueError(f"one of {options} must be given")
-        return v
+        return values
 
     return validator


### PR DESCRIPTION
Given what it does, this should have always been a root validator. Making it an individual field validator requires being too clever, and requires a very careful calling convention. Convert it to a root validator while we're making backward-incompatible changes.

Make the test suite use a real Pydantic model, which is a better test of how the validator works than calling it directly.