### PR TITLE
DM-38660: Add SlackWebException for HTTPX errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ X.Y.Z (YYYY-MM-DD)
 - The new `safir.redis.PydanticRedisStorage` class enables you to store Pydantic model objects in Redis.
   A `safir.redis.EncryptedPydanticRedisStorage` class also encrypts data in Redis.
   To use the `safir.redis` module, install Safir with the `redis` extra (i.e., `pip install safir[redis]`).
+- Add `safir.slack.webhook.SlackWebException`, which is a child class of `safir.slack.webhook.SlackException` that knows how to capture and report details from an underlying HTTPX exception.
 - Add a `safir.testing.kubernetes.strip_none` helper function that makes it easier to compare Kubernetes objects against expected test data.
 - Add a `get_namespace_objects_for_test` method to the Kubernetes mock to retreive all objects (of any kind) in a namespace.
 - Add a mock for the `list_nodes` Kubernetes API, which returns data set by a call to the new `set_nodes_for_test` method.
@@ -27,13 +28,13 @@ X.Y.Z (YYYY-MM-DD)
 - Add support for namespaced events (the older core API, not the new events API) to the Kubernetes mock. Newly-created pods with the default initial status post an event by default; otherwise, events must be created by calling the mocked `create_namespaced_event` API. The `list_namespaced_event` API supports watches with timeouts.
 - Add rudimentary support for `NetworkPolicy`, `ResourceQuota`, and `Service` objects to the Kubernetes mock.
 
-### Other changes
-
-- The `safir.testing.kubernetes.MockKubernetesApi` mock now has rudimentary API documentation for the Kubernetes APIs that it supports.
-
 ### Bug fixes
 
 - Stop adding the `X-Auth-Request-User` header to the OpenAPI schema for routes that use `auth_dependency` or `auth_logger_dependency`.
+
+### Other changes
+
+- The `safir.testing.kubernetes.MockKubernetesApi` mock now has rudimentary API documentation for the Kubernetes APIs that it supports.
 
 ## 3.8.0 (2023-03-15)
 
@@ -166,7 +167,7 @@ X.Y.Z (YYYY-MM-DD)
 
 ### Bug fixes
 
-- Restore previous `http_client_dependency` behavior by enabling following redirects by default. This adjusts for the change of defaults in httpx 0.20.0.
+- Restore previous `http_client_dependency` behavior by enabling following redirects by default. This adjusts for the change of defaults in HTTPX 0.20.0.
 
 ## 2.1.1 (2021-10-29)
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -18,3 +18,4 @@
 .. _PyPI: https://pypi.org/project/safir/
 .. _redis-py: https://redis.readthedocs.io/en/stable/
 .. _respx: https://lundberg.github.io/respx/
+.. _HTTPX: https://www.python-httpx.org/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,8 +12,10 @@ API reference
    :include-all-objects:
 
 .. automodapi:: safir.database
+   :include-all-objects:
 
 .. automodapi:: safir.datetime
+   :include-all-objects:
 
 .. automodapi:: safir.dependencies.arq
    :include-all-objects:
@@ -59,8 +61,10 @@ API reference
    :inherited-members:
 
 .. automodapi:: safir.slack.blockkit
+   :include-all-objects:
 
 .. automodapi:: safir.slack.webhook
+   :include-all-objects:
 
 .. automodapi:: safir.testing.gcs
    :include-all-objects:
@@ -69,5 +73,7 @@ API reference
    :include-all-objects:
 
 .. automodapi:: safir.testing.slack
+   :include-all-objects:
 
 .. automodapi:: safir.testing.uvicorn
+   :include-all-objects:

--- a/docs/user-guide/http-client.rst
+++ b/docs/user-guide/http-client.rst
@@ -1,9 +1,9 @@
 ######################
-Using the httpx client
+Using the HTTPX client
 ######################
 
 Safir helps you manage a single ``httpx.AsyncClient`` for your application.
-Using a single HTTP client improves performance by reusing connections.
+Using a single HTTPX_ client improves performance by reusing connections.
 
 Setting up the httpx.AsyncClient
 ================================

--- a/docs/user-guide/uvicorn.rst
+++ b/docs/user-guide/uvicorn.rst
@@ -2,7 +2,7 @@
 Starting an app with Uvicorn for testing
 ########################################
 
-Normally, testing of FastAPI apps should be done by passing the app to ``httpx.AsyncClient`` and using httpx's built-in support for sending requests directly to an ASGI application.
+Normally, testing of FastAPI apps should be done by passing the app to ``httpx.AsyncClient`` and using HTTPX's built-in support for sending requests directly to an ASGI application.
 To do this, use the ``client`` fixture provided by the ``fastapi_safir_app`` template (see :ref:`create-from-template`).
 
 However, in some test scenarios it may be necessary for the app being tested to respond to regular HTTP requests, such as for Selenium_ testing with a browser.

--- a/src/safir/dependencies/http_client.py
+++ b/src/safir/dependencies/http_client.py
@@ -15,7 +15,7 @@ __all__ = [
 DEFAULT_HTTP_TIMEOUT = 20.0
 """Default timeout (in seconds) for outbound HTTP requests.
 
-The default httpx timeout has proven too short in practice for calls to, for
+The default HTTPX timeout has proven too short in practice for calls to, for
 example, GitHub for authorization verification. Increase the default to 20
 seconds. Users of this dependency can always lower it if needed.
 """

--- a/src/safir/testing/uvicorn.py
+++ b/src/safir/testing/uvicorn.py
@@ -1,6 +1,6 @@
 """Utiility functions for managing an external Uvicorn test process.
 
-Normally, ASGI apps are tested via the built-in support in httpx for running
+Normally, ASGI apps are tested via the built-in support in HTTPX for running
 an ASGI app directly. However, sometimes the app has to be spawned in a
 separate process so that it can be accessed over HTTP, such as when testing it
 with Selenium or when testing Uvicorn integration. This module provides

--- a/tests/middleware/x_forwarded_test.py
+++ b/tests/middleware/x_forwarded_test.py
@@ -156,7 +156,7 @@ async def test_no_proto_or_host() -> None:
 async def test_too_many_headers() -> None:
     """Test handling of duplicate headers.
 
-    httpx doesn't allow passing in duplicate headers, so we cannot test end to
+    HTTPX doesn't allow passing in duplicate headers, so we cannot test end to
     end.  Instead, test by generating a mock request and then calling the
     underling middleware functions directly.
     """

--- a/tests/slack/webhook_test.py
+++ b/tests/slack/webhook_test.py
@@ -150,7 +150,7 @@ async def test_route_handler(mock_slack: MockSlackWebhook) -> None:
     app = FastAPI()
     app.include_router(router)
 
-    # We need a custom httpx configuration to disable raising server
+    # We need a custom HTTPX configuration to disable raising server
     # exceptions so that we can inspect the resulting error handling.
     transport = ASGITransport(
         app=app,  # type: ignore[arg-type]


### PR DESCRIPTION
Provide a SlackWebException base exception class, derived from SlackException, which understands how to extract useful information from HTTPX exceptions so that it can be reported to Slack. It also improves the stringification of HTTPX exceptions, which normally may not include the failing URL in the exception stringification.

Unfortunately, automodapi doesn't generate documentation for class or instance methods of exceptions, so the references to from_exception in the docs can't be links to the documentation.