### PR TITLE
DM-38660: Don't include body twice in SlackWebException

### DIFF
--- a/src/safir/slack/blockkit.py
+++ b/src/safir/slack/blockkit.py
@@ -381,6 +381,7 @@ class SlackWebException(SlackException):
             Slack message suitable for posting as an alert.
         """
         message = super().to_slack()
+        message.message = self.message
         if self.url:
             if self.method:
                 text = f"{self.method} {self.url}"


### PR DESCRIPTION
The serialization of SlackWebException for Slack reporting didn't take into account the addition of a __str__ method that added the body of the response. That should be omitted from the initial part of the Slack message since it's included in a later block. Adjust the serialization accordingly.