### PR TITLE
DM-38414: Add nested docstring for validate_exactly_one_of

### DIFF
--- a/src/safir/pydantic.py
+++ b/src/safir/pydantic.py
@@ -264,6 +264,7 @@ def validate_exactly_one_of(
         options = ", ".join(settings[:-1]) + ", and " + settings[-1]
 
     def validator(cls: type, values: dict[str, Any]) -> dict[str, Any]:
+        """Ensure only one of a list of fields is present and not `None`."""
         seen = False
         for setting in settings:
             if setting in values and values[setting] is not None:


### PR DESCRIPTION
When used with autodoc_pydantic, generating a summary of validators expects a docstring on the returned validator generated by validate_exactly_one_of. We can't make that great of a docstring, but put in something to avoid the warnings.