### PR TITLE
DM-38414: Use new tox v4 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ X.Y.Z (YYYY-MM-DD)
 ### Other changes
 
 - The `safir.testing.kubernetes.MockKubernetesApi` mock now has rudimentary API documentation for the Kubernetes APIs that it supports.
+- The documentation for running commands with `tox` has been updated for the new command-line syntax in tox v4.
 
 ## 3.8.0 (2023-03-15)
 

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -69,13 +69,13 @@ To test the library, run tox_, which tests the library the same way that the CI 
 
 .. code-block:: sh
 
-   tox
+   tox run
 
 To see a listing of test environments, run:
 
 .. code-block:: sh
 
-   tox -av
+   tox list
 
 tox will start a PostgreSQL container, which is required for some tests.
 
@@ -84,7 +84,7 @@ For example:
 
 .. code-block:: sh
 
-   tox -e py -- tests/database_test.py
+   tox run -e py -- tests/database_test.py
 
 .. _dev-build-docs:
 
@@ -97,7 +97,7 @@ Documentation is built with Sphinx_:
 
 .. code-block:: sh
 
-   tox -e docs
+   tox run -e docs
 
 The build documentation is located in the :file:`docs/_build/html` directory.
 
@@ -148,7 +148,7 @@ Code
 - The code style follows :pep:`8`, though in practice lean on Black and isort to format the code for you.
 
 - Use :pep:`484` type annotations.
-  The ``tox -e typing`` test environment, which runs mypy_, ensures that the project's types are consistent.
+  The ``tox run -e typing`` test environment, which runs mypy_, ensures that the project's types are consistent.
 
 - Write tests for Pytest_.
 

--- a/docs/user-guide/set-up-from-template.rst
+++ b/docs/user-guide/set-up-from-template.rst
@@ -95,7 +95,7 @@ You can format the code and by running tox_:
 
 .. prompt:: bash
 
-   tox -e lint
+   tox run -e lint
    git commit -a
 
 6. Push to GitHub
@@ -137,32 +137,32 @@ An even better, and more robust approach is with tox:
 
 .. prompt:: bash
 
-   tox
+   tox run
 
 Tox runs several test steps, each in their own virtual environment.
 To learn about these test steps:
 
 .. prompt:: bash
 
-   tox -av
+   tox list
 
 For example, to only run mypy to check type annotations:
 
 .. prompt:: bash
 
-   tox -e typing
+   tox run -e typing
 
 Or to only lint the code (and reformat it):
 
 .. prompt:: bash
 
-   tox -e lint
+   tox run -e lint
 
 To run all the default test steps, but in parallel:
 
 .. prompt:: bash
 
-   tox -p auto
+   tox run-parallel -p auto
 
 9. Try the local development server
 ===================================
@@ -171,7 +171,7 @@ In addition to running tests, tox is also configured with a command to spin up a
 
 .. prompt:: bash
 
-   tox -e run
+   tox run -e run
 
 In another shell, send an HTTP GET request to the development server:
 


### PR DESCRIPTION
tox v4 added subcommands as the preferred command-line syntax. Executing it without subcommands invokes a default subcommand called "legacy" and the upgrading documentation recommends always using subcommands for tox run and when there may be a conflict with an environment name. Update the documentation to always use the new syntax.