### PR TITLE
DM-38795: Fix concurrency for event watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ X.Y.Z (YYYY-MM-DD)
 
 - Add `read_*` methods for `ConfigMap` and `ResourceQuota` to the mock Kubernetes API for testing.
 
+### Bug fixes
+
+- Fix concurrency locking when watching namespace events in the Kubernetes testing mock. The previous logic degenerated into busy-waiting rather than correctly waiting on a condition variable.
+
 ## 4.0.0 (2023-04-19)
 
 ### Backwards-incompatible changes

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -592,7 +592,8 @@ class MockKubernetesApi:
                         yield b""
                         return
                     try:
-                        await asyncio.wait_for(wait_event.wait(), timeout_left)
+                        async with asyncio.timeout(timeout_left):
+                            await wait_event.wait()
                     except TimeoutError:
                         yield b""
                         return


### PR DESCRIPTION
The Kubernetes mock was never clearing the `asyncio.Event` used to signal that new namespace events were available, so it was essentially busy-waiting, which in turn starved other tasks and caused very confusing bugs. Adopt the same strategy as Nublado and use separate events per consumer so that they can be triggered separately.

Also switch from `asyncio.wait_for` to `asyncio.timeout`. This turned out to be unrelated to the problem, but some research showed that `asyncio.timeout` is much simpler and has fewer edge-case bugs.