### PR TITLE
DM-38795: Add watch support for list_namespaced_pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ X.Y.Z (YYYY-MM-DD)
 ### New features
 
 - Add `read_*` methods for `ConfigMap` and `ResourceQuota` to the mock Kubernetes API for testing.
+- Add `patch_namespaced_pod_status` to the mock Kubernetes API for testing. Application code is unlikely to call this, but it's useful for test suites.
+- The mock `list_namespaced_pod` Kubernetes API now supports watches (but be aware that all changes must be made through the API).
 
 ### Bug fixes
 
 - Fix concurrency locking when watching namespace events in the Kubernetes testing mock. The previous logic degenerated into busy-waiting rather than correctly waiting on a condition variable.
+- Watches for namespace events using the mock Kubernetes API now start with the next event, not the first stored event, if `resource_version` is not set, aligning behavior with the Kubernetes API.
 
 ## 4.0.0 (2023-04-19)
 


### PR DESCRIPTION
Move the machinery for event watches in the Kubernetes mock into a separate private class.

Make use of that machinery to add watch support for list_namespaced_pod. Add patch_namespaced_pod_status to change the phase, primarily for tests (application code is unlikely to call this since pod phase is handled by Kubernetes itself).

If the resource version is not specified to a watch, the watch now starts with the next event, not the first recorded event, to match the behavior of the Kubernetes API.