### PR TITLE
DM-38425: Extract more data from httpx exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Headline template:
 X.Y.Z (YYYY-MM-DD)
 -->
 
+## 4.1.1 (unreleased)
+
+### Bug fixes
+
+- `SlackWebException` now extracts the method and URL of the request from more httpx exceptions, and avoids exceptions when the request information is not present.
+
 ## 4.1.0 (2023-05-08)
 
 ### New features


### PR DESCRIPTION
Previously, SlackWebException assumed that if an httpx exception inherited from RequestError, it would have a request attribute, and if it didn't, it wouldn't. This turns out to be incorrect; some RequestError exceptions may not have a request for various reasons, and some that do not inherit from RequestError do.

Adjust the exception parsing to take this into account by attempting to extract the request and falling back on the non-request handling on any error.

Fix one place where SlackTextField was used instead of SlackTextBlock for something added to the message blocks. (The different length restriction is unlikely to matter in practice, but this is more correct.)