### PR TITLE
DM-39251: Switch to scriv for change log management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change log
 
-<!--
-Headline template:
-X.Y.Z (YYYY-MM-DD)
--->
+All notable changes to Safir will be documented in this file.
+
+Versioning follows [semver](https://semver.org/).
+
+This project uses [scriv](https://scriv.readthedocs.io/) to maintain the change log.
+Changes for the upcoming release can be found in [changelog.d](https://github.com/lsst-sqre/safir/tree/main/changelog.d/).
+
+<!-- scriv-insert-here -->
 
 ## 4.2.1 (2023-05-17)
 

--- a/changelog.d/20230517_100025_rra_DM_39251.md
+++ b/changelog.d/20230517_100025_rra_DM_39251.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Safir now uses [scriv](https://scriv.readthedocs.io/en/latest/) to maintain its change log.

--- a/changelog.d/_template.md
+++ b/changelog.d/_template.md
@@ -1,0 +1,7 @@
+<!-- Delete the sections that don't apply -->
+{%- for cat in config.categories %}
+
+### {{ cat }}
+
+-
+{%- endfor %}

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -16,6 +16,8 @@
 .. _redis-py: https://redis.readthedocs.io/en/stable/
 .. _respx: https://lundberg.github.io/respx/
 .. _Roundtable: https://roundtable.lsst.io
+.. _scriv: https://scriv.readthedocs.io/en/stable/
+.. _semver: https://semver.org/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _structlog: https://www.structlog.org/en/stable/
 .. _templatekit: https://templatekit.lsst.io

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -106,36 +106,27 @@ The build documentation is located in the :file:`docs/_build/html` directory.
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.md`).
-Add a description of new features and fixes as list items under a section at the top of the change log, using ``unreleased`` for the date portion.
-The version number for that heading should be chosen or updated based on the semver_ rules.
+Safir uses scriv_ to maintain its change log.
 
-.. _semver: https://semver.org/
+When preparing a pull request, run :command:`scriv create`.
+This will create a change log fragment in :file:`changelog.d`.
+Edit that fragment, removing the sections that do not apply and adding entries fo this pull request.
+You can pass the ``--edit`` flag to :command:`scriv create` to open the created fragment automatically in an editor.
 
-.. code-block:: markdown
+Change log entries use the following sections:
 
-   ## X.Y.Z (unreleased)
-
-   ### Subheading (see below)
-
-   - Description of the feature or fix.
-
-All changelog entries should be divided into sections (each starting with ``###``) chosen from the following:
-
-- **Backward-incompatible changes** (also increase the major version except in unusual cases)
-- **New features** (also increase the minor version except in unusual cases)
+- **Backward-incompatible changes**
+- **New features**
 - **Bug fixes**
-- **Other changes** (which are mostly new features that are not significant enough to call attention to, such as logging formatting changes or updates to the documentation)
+- **Other changes** (for minor, patch-level changes that are not bug fixes, such as logging formatting changes or updates to the documentation)
 
-If the exact version and release date is known (:doc:`because a release is being prepared <release>`), the section header is formatted as:
+These entries will eventually be cut and pasted into the release description for the next release, so the Markdown for the change descriptions should be compatible with GitHub's Markdown conventions for the release description.
+Specifically:
 
-.. code-block:: markdown
-
-   ## X.Y.Z (YYYY-MM-DD)
-
-Each entry in the change log should be on one line without line breaks, even though this violates the normal rule of putting a newline after each sentence.
-This allows the whole change log entry to be copied and pasted into the GitHub release page when creating a release.
-Unfortunately, GitHub Markdown preserves line breaks after sentences as hard line breaks when rendering the description of a release.
+- Each bullet point should be entirely on one line, even if it contains multiple sentences.
+  This is an exception to the normal documentation convention of a newline after each sentence.
+  Unfortunately, GitHub interprets those newlines as hard line breaks, so they would result in an ugly release description.
+- Avoid using too much complex markup, such as nested bullet lists, since the formatting in the GitHub release description may not be what you expect and manually editing it is tedious.
 
 .. _style-guide:
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -26,11 +26,26 @@ Release tags are semantic version identifiers following the :pep:`440` specifica
 1. Change log and documentation
 -------------------------------
 
-Each PR should include updates to the change log.
-If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``main`` branch.
+Change log messages for each release are accumulated using scriv_.
+See :ref:`dev-change-log` in the *Developer guide* for more details.
 
-In particular, replace the "Unreleased" section headline with the semantic version and date.
-See :ref:`dev-change-log` in the *Developer guide* for details.
+When it comes time to make the release, there should be a collection of change log fragments in :file:`changelog.d`.
+Those fragments will make up the change log for the new release.
+
+Review those fragments to determine the version number of the next release.
+Safir follows semver_, so follow its rules to pick the next version:
+
+- If there are any backward-incompatible changes, incremeent the major version number and set the other numbers to 0.
+- If there are any new features, increment the minor version number and set the patch version to 0.
+- Otherwise, increment the patch version number.
+
+Then, run ``scriv collect --version <version>`` specifying the version number you decided on.
+This will delete the fragment files and collect them into :file:`CHANGELOG.md` under an entry for the new release.
+Review that entry and edit it as needed (proofread, change the order to put more important things first, etc.).
+scriv will put blank lines between entries from different files.
+You may wish to remove those blank lines to ensure consistent formatting by various Markdown parsers.
+
+Finally, create a PR from those changes and merge it before continuing with the release process.
 
 2. Tag the release
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "respx",
+    "scriv",
     "sqlalchemy[mypy]",
     "types-redis",
     "uvicorn",
@@ -168,3 +169,16 @@ init_forbid_extra = true
 init_typed = true
 warn_required_dynamic_aliases = true
 warn_untyped_fields = true
+
+[tool.scriv]
+categories = [
+    "Backwards-incompatible changes",
+    "New features",
+    "Bug fixes",
+    "Other changes",
+]
+entry_title_template = "{{ version }} ({{ date.strftime('%Y-%m-%d') }})"
+format = "md"
+md_header_level = "2"
+new_fragment_template = "file:changelog.d/_template.md"
+skip_fragments = "_template.md"


### PR DESCRIPTION
scriv maintains change logs in individual fragments that can be merged with the corresponding PR without creating merge conflicts, and then assembles those fragments into a new change log entry during the release process. Move the pending changes to a scriv fragment, add a scriv configuration, and update the development and release documentation to document use of scriv.

Also note in the preamble of the change log that Safir follows semver.