### PR TITLE
DM-38933: Revert MockKuberntesApi doc change in 4.2.1

### DIFF
--- a/changelog.d/20230517_140715_rra_DM_38933.md
+++ b/changelog.d/20230517_140715_rra_DM_38933.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Revert the documentation change in 4.2.1 to restore cross-references, since the docs-linkcheck failure appears to be a false positive.

--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -362,9 +362,8 @@ class MockKubernetesApi:
     approach we picked.)
 
     Most APIs do not support watches. The current exceptions are
-    ``list_namespaced_event``, ``list_namespaced_ingress``,
-    ``list_namespaced_job``, ``list_namespaced_pod``, and
-    ``list_namespaced_service``.
+    `list_namespaced_event`, `list_namespaced_ingress`, `list_namespaced_job`,
+    `list_namespaced_pod`, and `list_namespaced_service`.
 
     Attributes
     ----------


### PR DESCRIPTION
The references to methods in the MockKubernetesApi docstring were intended to be cross-references, and the docs-linkcheck failure seems to go away once the docs target is run first. Revert the documentation change in 4.2.1 in the hope that this was a false positive.