### PR TITLE
DM-38933: Fix redirects in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Safir will be documented in this file.
 
 Versioning follows [semver](https://semver.org/).
 
-This project uses [scriv](https://scriv.readthedocs.io/) to maintain the change log.
+This project uses [scriv](https://scriv.readthedocs.io/en/stable/) to maintain the change log.
 Changes for the upcoming release can be found in [changelog.d](https://github.com/lsst-sqre/safir/tree/main/changelog.d/).
 
 <!-- scriv-insert-here -->

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -10,7 +10,7 @@
 .. _mypy: https://www.mypy-lang.org
 .. _Phalanx: https://phalanx.lsst.io
 .. _pre-commit: https://pre-commit.com
-.. _Pydantic: https://docs.pydantic.dev/
+.. _Pydantic: https://docs.pydantic.dev/latest/
 .. _PyPI: https://pypi.org/project/safir/
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _redis-py: https://redis.readthedocs.io/en/stable/

--- a/docs/user-guide/github-apps/create-a-github-client.rst
+++ b/docs/user-guide/github-apps/create-a-github-client.rst
@@ -10,7 +10,7 @@ To create a Gidgethub client for a GitHub App, Safir provides the `safir.github.
 .. note::
 
    GitHub provides multiple way of building integrations, each with slightly different capabilities and authentication flows.
-   The `GitHubAppClientFactory` is designed to work with `GitHub Apps <https://developer.github.com/apps/building-github-apps/>`__, which are the recommended way of building integrations.
+   The `GitHubAppClientFactory` is designed to work with `GitHub Apps <https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app>`__, which are the recommended way of building integrations.
    GitHub Apps are specifically installed into an organization or user account, and can be granted access to specific repositories.
 
    Another common way of building an integration is as an OAuth app (particularly before the introduction of GitHub Apps).
@@ -21,13 +21,13 @@ To create a Gidgethub client for a GitHub App, Safir provides the `safir.github.
    GitHub Apps generally replace this use case for all but the simplest integrations.
    Note in particular that a GitHub App can be `authenticated on behalf of a user <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-with-a-github-app-on-behalf-of-a-user>`__.
 
-   For a comparison of the different ways of building integrations, see `GitHub's documentation <https://docs.github.com/en/apps/creating-github-apps/creating-github-apps/about-apps>`__.
+   For a comparison of the different ways of building integrations, see `GitHub's documentation <https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/about-creating-github-apps>`__.
 
 Setting up the factory
 ======================
 
 The `GitHubAppClientFactory` requires information about the GitHub App, which you will normally include in your application's configuration, and an instance of `httpx.AsyncClient`, which your application will typically create with the `~safir.dependencies.http_client.http_client_dependency` dependency (see :doc:`../http-client`).
-For information about creating a GitHub App, retrieving its App ID and generating a private key, see `GitHub's documentation <https://developer.github.com/apps/building-github-apps/creating-a-github-app/>`__.
+For information about creating a GitHub App, retrieving its App ID and generating a private key, see `GitHub's documentation <https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app>`__.
 
 .. code-block:: python
 

--- a/docs/user-guide/github-apps/webhook-models.rst
+++ b/docs/user-guide/github-apps/webhook-models.rst
@@ -21,17 +21,17 @@ GitHub events
 
    * - Event
      - Model
-   * - `check_run <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run>`__
+   * - `check_run <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run>`__
      - `~safir.github.webhooks.GitHubCheckRunEventModel`
-   * - `check_suite <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite>`__
+   * - `check_suite <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite>`__
      - `~safir.github.webhooks.GitHubCheckSuiteEventModel`
-   * - `installation <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#installation>`__
+   * - `installation <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation>`__
      - `~safir.github.webhooks.GitHubAppInstallationEventModel`
-   * - `installation_repositories <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories>`__
+   * - `installation_repositories <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories>`__
      - `~safir.github.webhooks.GitHubAppInstallationRepositoriesEventModel`
-   * - `pull_request <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request>`__
+   * - `pull_request <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request>`__
      - `~safir.github.webhooks.GitHubPullRequestEventModel`
-   * - `push <https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#push>`__
+   * - `push <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push>`__
      - `~safir.github.webhooks.GitHubPushEventModel`
 
 Related documentation

--- a/src/safir/github/webhooks.py
+++ b/src/safir/github/webhooks.py
@@ -42,7 +42,7 @@ class GitHubPushEventModel(BaseModel):
     """A Pydantic model for the ``push`` event webhook when a commit or
     tag is pushed.
 
-    https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push
     """
 
     repository: GitHubRepositoryModel = Field(
@@ -74,7 +74,7 @@ class GitHubAppInstallationEventRepoModel(BaseModel):
     """A pydantic model for repository objects used by
     `GitHubAppInstallationRepositoriesEventModel`.
 
-    https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
     """
 
     name: str = Field(
@@ -119,7 +119,7 @@ class GitHubAppInstallationEventAction(str, Enum):
 class GitHubAppInstallationEventModel(BaseModel):
     """A Pydantic model for an ``installation`` webhook.
 
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
     """
 
     action: GitHubAppInstallationEventAction = Field(
@@ -150,7 +150,7 @@ class GitHubAppInstallationRepositoriesEventAction(str, Enum):
 class GitHubAppInstallationRepositoriesEventModel(BaseModel):
     """A Pydantic model for a ``installation_repositories`` webhook.
 
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories
     """
 
     action: GitHubAppInstallationRepositoriesEventAction = Field(
@@ -244,7 +244,7 @@ class GitHubPullRequestEventAction(str, Enum):
 class GitHubPullRequestEventModel(BaseModel):
     """A Pydantic model for a ``pull_request`` webhook.
 
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
     """
 
     repository: GitHubRepositoryModel = Field(
@@ -286,7 +286,7 @@ class GitHubCheckSuiteEventAction(str, Enum):
 class GitHubCheckSuiteEventModel(BaseModel):
     """A Pydantic model for the ``check_suite`` webhook payload.
 
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite
     """
 
     action: GitHubCheckSuiteEventAction = Field(
@@ -329,7 +329,7 @@ class GitHubCheckRunEventAction(str, Enum):
 class GitHubCheckRunEventModel(BaseModel):
     """A Pydantic model for the ``check_run`` webhook payload.
 
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run
+    https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run
     """
 
     action: GitHubCheckRunEventAction = Field(

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -121,7 +121,7 @@ def configure_logging(
     Notes
     -----
     This function helps you configure a useful logging set up for your
-    application that's based on `structlog <https://www.structlog.org>`__.
+    application that's based on structlog_.
 
     First, it configures the logger for your application to log to STDOUT.
     Second, it configures the formatting of your log messages through


### PR DESCRIPTION
Go through docs-linkcheck and convert permanent redirects to their targets, with the exception of a small handful that don't have a stable canonical link.