### PR TITLE
DM-39249: Put response from SlackWebException in attachment

### DIFF
--- a/changelog.d/20230518_074803_rra_DM_39249a.md
+++ b/changelog.d/20230518_074803_rra_DM_39249a.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When reporting an error response to Slack using `SlackWebException`, put the response body in an attachment instead of a regular block, since it may be a full HTML error page. An attachment tells Slack to hide long content by default unless the viewer expands it.

--- a/src/safir/slack/blockkit.py
+++ b/src/safir/slack/blockkit.py
@@ -398,7 +398,7 @@ class SlackWebException(SlackException):
             message.blocks.append(SlackTextBlock(heading="URL", text=text))
         if self.body:
             block = SlackCodeBlock(heading="Response", code=self.body)
-            message.blocks.append(block)
+            message.attachments.append(block)
         return message
 
 


### PR DESCRIPTION
The response portion of a SlackWebException may be a full HTML page, so put it in an attachment rather than a block when formatting it for Slack so that Slack will hide long content by default and add an expand option.