### PR TITLE
DM-39710: Patch create_app_client to preset JWT

### DIFF
--- a/src/safir/github/_client.py
+++ b/src/safir/github/_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import partialmethod
 from typing import Optional
 
 import gidgethub.apps
@@ -73,7 +74,31 @@ class GitHubAppClientFactory:
         gidgethub.httpx.GitHubAPI
             The app client.
         """
-        return self._create_client(oauth_token=self.get_app_jwt())
+        jwt = self.get_app_jwt()
+        client = self._create_client()
+
+        client.getitem = partialmethod(  # type: ignore[assignment]
+            client.getitem, jwt=jwt
+        )
+        # getstatus is an upcoming gidgethub feature
+        # client.getstatus = partialmethod(client.getstatus, jwt=jwt)
+        client.getiter = partialmethod(  # type: ignore[assignment]
+            client.getiter, jwt=jwt
+        )
+        client.post = partialmethod(  # type: ignore[assignment]
+            client.post, jwt=jwt
+        )
+        client.patch = partialmethod(  # type: ignore[assignment]
+            client.patch, jwt=jwt
+        )
+        client.put = partialmethod(  # type: ignore[assignment]
+            client.put, jwt=jwt
+        )
+        client.delete = partialmethod(  # type: ignore[assignment]
+            client.delete, jwt=jwt
+        )
+
+        return client
 
     async def create_installation_client(
         self, installation_id: str


### PR DESCRIPTION
This fixes `GitHubAppClientFactory.create_app_client`. I mistakenly though that the oauth_token attribute on the GitHubAPI constructor could be used to cache the app's JWT. It turns out that the JWT is treated entirely separately, and currently can't be cached in GitHubAPI. Instead, the JWT needs to be passed to each request method. This commit achieves the desired behaviour by patching the Gidgethub GitHubAPI methods to always set the jwt keyword argument.