### PR TITLE
Pin major versions of dependencies

### DIFF
--- a/changelog.d/20230717_082750_rra_versions.md
+++ b/changelog.d/20230717_082750_rra_versions.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Safir now pins the major version of all of its non-development dependencies. The impetus for this change is to prevent upgrades to Pydantic 2.x until Safir's Pydantic models are ready for that upgrade, but a similar principle applies to other dependencies. These pins will be selectively relaxed once Safir has been confirmed to work with a new major release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,23 +22,23 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "cryptography",
-    "fastapi",
-    "gidgethub",
-    "httpx>=0.20.0",
-    "pydantic",
-    "starlette",
-    "structlog>=21.2.0",
+    "cryptography<42",
+    "fastapi<1",
+    "gidgethub<6",
+    "httpx>=0.20.0,<1",
+    "pydantic<2",
+    "starlette<1",
+    "structlog>=21.2.0,<24",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 arq = [
-    "arq>=0.23"
+    "arq>=0.23,<1"
 ]
 db = [
-    "asyncpg",
-    "sqlalchemy[asyncio]>=1.4.18",
+    "asyncpg<1",
+    "sqlalchemy[asyncio]>=1.4.18,<3",
 ]
 dev = [
     "asgi-lifespan",
@@ -55,18 +55,18 @@ dev = [
     "types-redis",
     "uvicorn",
     # documentation
-    "documenteer[guide]>=0.7.0b2",
+    "documenteer[guide]>=0.7.0,<1",
     "autodoc_pydantic",
 ]
 gcs = [
-    "google-auth",
-    "google-cloud-storage"
+    "google-auth<3",
+    "google-cloud-storage<3"
 ]
 kubernetes = [
-    "kubernetes_asyncio"
+    "kubernetes_asyncio<25"
 ]
 redis = [
-    "redis>=4.2.0rc1,!=4.5.2", # https://github.com/redis/redis-py/issues/2633
+    "redis>4.5.2,<5",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
Add pins on the major version of each dependency. For those with versions less than 1, pin on <1 even though semver says the minor versions may have backward-incompatible changes, since those dependencies (FastAPI, Starlette, httpx) mostly don't do that and can have a lot of version churn.

Also pin documenteer <1, and move the lower version bound to a non-beta release because referencing any alpha or beta release in a dependency tells pip it's allowed to install any other alpha or beta release instead of sticking only to full releases.

Move the lower bound for the Redis dependency past the version that fixes typing to simplify the version constraint. There doesn't seem to be a good reason to use old versions of the Redis library.