### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 
 "on":
+  merge_group: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -11,9 +13,8 @@ name: Python CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
-    tags:
-      - "*"
-  pull_request: {}
+  release:
+    types: [published]
 
 jobs:
 
@@ -83,8 +84,10 @@ jobs:
           github.event_name != 'pull_request'
           || startsWith(github.head_ref, 'tickets/')
 
-  pypi:
+  test-packaging:
 
+    name: Test packaging
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
 
@@ -94,8 +97,29 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
           python-version: "3.11"
-          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          upload: false
+
+  pypi:
+
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [lint, test, docs, test-packaging]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/safir
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          python-version: "3.11"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -1,5 +1,5 @@
 # This is a separate run of the Python test suite that doesn't cache the tox
-# environment and runs from a schedule.  The purpose is to test compatibility
+# environment and runs from a schedule. The purpose is to test compatibility
 # with the latest versions of all modules Safir depends on, since Safir (being
 # a library) does not pin its dependencies.
 
@@ -8,6 +8,7 @@ name: Periodic CI
 "on":
   schedule:
     - cron: "0 12 * * 1"
+  workflow_dispatch: {}
 
 jobs:
   test:
@@ -29,6 +30,16 @@ jobs:
           tox-plugins: "tox-docker"
           use-cache: false
 
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
   docs:
     runs-on: ubuntu-latest
 
@@ -45,8 +56,20 @@ jobs:
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
 
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic documentation build for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
   pypi:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [test, docs]
 
     steps:
       - uses: actions/checkout@v3
@@ -54,8 +77,17 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ""
           python-version: "3.11"
           upload: false
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic PyPI test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Upgrade to v2 of lsst-sqre/build-and-publish-to-pypi and use a trusted environment for upload instead of an organization secret. Add a separate test-packaging target that always runs. Trigger PyPI upload on GitHub release rather than a tag.

Add workflow triggers to make it easier to manually test workflows.

Rename periodic.yaml to periodic-ci.yaml to match the template, and add alerts to Slack if the periodic CI runs fail.