### PR TITLE
DM-40567: Add a helper function for Click command help

### DIFF
--- a/changelog.d/20230830_155927_rra_DM_40567.md
+++ b/changelog.d/20230830_155927_rra_DM_40567.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a `safir.click.display_help` helper function that implements a `help` command for Click-based command-line interfaces, with support for nested subcommands.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,9 @@ API reference
 .. automodapi:: safir.asyncio
    :include-all-objects:
 
+.. automodapi:: safir.click
+   :include-all-objects:
+
 .. automodapi:: safir.database
    :include-all-objects:
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -29,6 +29,7 @@ extensions = [
 
 [sphinx.intersphinx.projects]
 arq = "https://arq-docs.helpmanual.io"
+click = "https://click.palletsprojects.com/"
 cryptography = "https://cryptography.io/en/latest/"
 gidgethub = "https://gidgethub.readthedocs.io/en/latest/"
 python = "https://docs.python.org/3/"

--- a/docs/user-guide/click.rst
+++ b/docs/user-guide/click.rst
@@ -1,0 +1,75 @@
+#######################################
+Using Click for command-line interfaces
+#######################################
+
+The Python library Click_ is the recommended way of creating command-line interfaces for applications that use Safir.
+Click provides a simple API for creating command-line interfaces that use the easily-extensible command and subcommand pattern, similar to Git and many other tools.
+
+Safir provides some support functions to make those command-line interfaces easier to write.
+
+Implementing a help command
+===========================
+
+Click provides native support for the ``--help`` command-line flag for all commands and subcommands.
+However, another common pattern for good command-line tools is to support a separate ``help`` command that takes other commands as arguments.
+
+For example, if the command-line tool :command:`example` has a command :command:`example create`, a common pattern is for :command:`example help create` to show the help output for that ``create`` command.
+This should also work with nested subcommands, such as the command :command:`example create object` and the corresponding help command :command:`example help create object`.
+
+Safir provides a utility function, `safir.click.display_help`, which implements this ``help`` command.
+Here is the typical usage:
+
+.. code-block:: python
+
+   import click
+
+   from safir.click import display_help
+
+
+   @click.group(context_settings={"help_option_names": ["-h", "--help"]})
+   @click.version_option(message="%(version)s")
+   def main() -> None:
+       """Example command-line interface."""
+
+
+   @main.command()
+   @click.argument("topic", default=None, required=False, nargs=1)
+   @click.argument("subtopic", default=None, required=False, nargs=1)
+   @click.pass_context
+   def help(
+       ctx: click.Context, topic: str | None, subtopic: str | None
+   ) -> None:
+       """Show help for any command."""
+       display_help(main, ctx, topic, subtopic)
+
+This also shows the recommended pattern for defining the top-level Click command group, which is conventionally called ``main``.
+
+Additional commands can then be defined in the normal way, using the ``@main.command()`` decorator (or a nested command group under ``main``), and documented in the normal way using the ``help`` parameter to Click decorators and the docstring of the function defining the command.
+That documentation will be picked up automatically by `safir.click.display_help`.
+
+Running Click commands using asyncio
+====================================
+
+Click itself is a synchronous library and has no built-in support for command handlers using asyncio.
+To make it easier to write command-line interfaces for asyncio applications, Safir provides the decorator `safir.asyncio.run_with_asyncio` that integrates with Click commands.
+
+For example, here is the definition of a ``do-something`` command that uses asyncio:
+
+.. code-block:: python
+
+   import click
+
+   from safir.asyncio import run_with_asyncio
+
+
+   # Definition of main omitted.
+
+
+   @main.command()
+   @run_with_asyncio
+   async def do_something() -> None:
+       await some_async_call()
+
+This decorator will invoke the decorated function with `asyncio.run`, so the caller must not already be inside an asyncio task.
+
+This decorator can be used in any situation where a function needs to be invoked via `asyncio.run`, not just for Click commands, but Click commands are the most common instance of this need for applications based on Safir.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -30,3 +30,4 @@ User guide
    uvicorn
    slack-webhook
    github-apps/index
+   click

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "click<9",
     "cryptography<42",
     "fastapi<1",
     "gidgethub<6",

--- a/src/safir/click.py
+++ b/src/safir/click.py
@@ -1,0 +1,89 @@
+"""Click command-line interface support."""
+
+from __future__ import annotations
+
+import click
+
+__all__ = ["display_help"]
+
+
+def display_help(
+    main: click.Group,
+    ctx: click.Context,
+    topic: str | None,
+    subtopic: str | None,
+) -> None:
+    """Show help for a Click command.
+
+    This function implements a help command for command-line interfaces using
+    Click_. It supports commands and subcommands, displaying the same
+    information as would be shown by ``--help``. The resulting help text is
+    displayed with `click.echo`.
+
+    Parameters
+    ----------
+    main
+        Top-level Click command group.
+    ctx
+        Click context.
+    topic
+        Command for which to get help.
+    subtopic
+        Subcommand of that command for which to get help.
+
+    Raises
+    ------
+    click.UsageError
+        Raised if the given help topic or subtopic does not correspond to a
+        registered Click command.
+    RuntimeError
+        Raised if the Click context has no parent, meaning that this was
+        called with an invalid context or from the top-level Click command.
+
+    Returns
+    -------
+    `None`
+
+    Examples
+    --------
+    This function should normally be called from a top-level ``help`` command.
+    Assuming that the top-level Click group is named ``main``, here is the
+    typical usage:
+
+    .. code-block:: python
+
+       @main.command()
+       @click.argument("topic", default=None, required=False, nargs=1)
+       @click.argument("subtopic", default=None, required=False, nargs=1)
+       @click.pass_context
+       def help(
+           ctx: click.Context, topic: str | None, subtopic: str | None
+       ) -> None:
+           display_help(main, ctx, topic, subtopic)
+    """
+    if not topic:
+        if not ctx.parent:
+            raise RuntimeError("help called without topic or parent")
+        click.echo(ctx.parent.get_help())
+        return
+    if topic not in main.commands:
+        raise click.UsageError(f"Unknown help topic {topic}", ctx)
+    if not subtopic:
+        ctx.info_name = topic
+        click.echo(main.commands[topic].get_help(ctx))
+        return
+
+    # Subtopic handling. This requires some care with typing, since the
+    # commands attribute (although present) is not documented, and the
+    # get_command method is only available on MultiCommands.
+    group = main.commands[topic]
+    if isinstance(group, click.MultiCommand):
+        command = group.get_command(ctx, subtopic)
+        if command:
+            ctx.info_name = f"{topic} {subtopic}"
+            click.echo(command.get_help(ctx))
+            return
+
+    # Fall through to the error case of no subcommand found.
+    msg = f"Unknown help topic {topic} {subtopic}"
+    raise click.UsageError(msg, ctx)

--- a/src/safir/click.py
+++ b/src/safir/click.py
@@ -10,8 +10,8 @@ __all__ = ["display_help"]
 def display_help(
     main: click.Group,
     ctx: click.Context,
-    topic: str | None,
-    subtopic: str | None,
+    topic: str | None = None,
+    subtopic: str | None = None,
 ) -> None:
     """Show help for a Click command.
 

--- a/tests/click_test.py
+++ b/tests/click_test.py
@@ -1,0 +1,49 @@
+"""Tests for Click utility functions."""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from safir.click import display_help
+
+
+def test_display_help() -> None:
+    @click.group()
+    def main() -> None:
+        """Some command."""
+
+    @main.command()
+    @click.argument("topic", default=None, required=False, nargs=1)
+    @click.argument("subtopic", default=None, required=False, nargs=1)
+    @click.pass_context
+    def help(
+        ctx: click.Context, topic: str | None, subtopic: str | None
+    ) -> None:
+        """Show help for any command."""
+        display_help(main, ctx, topic, subtopic)
+
+    @main.command()
+    def foo() -> None:
+        """Run foo."""
+        click.echo("Ran foo")
+
+    @main.group()
+    def bar() -> None:
+        """Bar commands."""
+
+    @bar.command()
+    def something() -> None:
+        """Do something with a bar."""
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["help"], catch_exceptions=False)
+    assert "Some command" in result.output
+    result = runner.invoke(main, ["help", "foo"], catch_exceptions=False)
+    assert "main foo [OPTIONS]" in result.output
+    assert "Run foo" in result.output
+    result = runner.invoke(
+        main, ["help", "bar", "something"], catch_exceptions=False
+    )
+    assert "main bar something [OPTIONS]" in result.output
+    assert "Do something with a bar" in result.output


### PR DESCRIPTION
For the Phalanx command-line tool, I added support for a second level of commands to the standard help boilerplate. The result is complex enough that it seems worth lifting into Safir proper rather than existing only in a template. The result is a new safir.click module providing a display_help function.

Add documentation of the run_with_asyncio decorator to the new user guide page about Click support, since this is the most common place where that decorator is used.