### PR TITLE
DM-40638: Add AsyncMultiQueue data structure

### DIFF
--- a/changelog.d/20230905_090034_rra_DM_40638.md
+++ b/changelog.d/20230905_090034_rra_DM_40638.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `safir.asyncio.AsyncMultiQueue` data structure, which is an asyncio multi-reader queue that delivers all messages to each reader independently.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ API reference
 
 .. automodapi:: safir.asyncio
    :include-all-objects:
+   :inherited-members:
 
 .. automodapi:: safir.click
    :include-all-objects:

--- a/docs/user-guide/asyncio-queue.rst
+++ b/docs/user-guide/asyncio-queue.rst
@@ -18,11 +18,18 @@ The writer should use the queue as follows:
    queue = AsyncMultiQueue[str]()
    queue.put("soemthing")
    queue.put("else")
+   queue.close()
 
-   # Calling clear will deliver the contents of the queue to all readers
-   # and then tell them that the queue of data has ended so their
-   # iterators will stop.
+Once `~safir.asyncio.AsyncMultiQueue.close` is called, no more data can be added to the queue, and the iterators for all readers will stop when they reach the point where `~safir.asyncio.AsyncMultiQueue.close` was called.
+
+To reset the queue entirely, use `~safir.asyncio.AsyncMultiQueue.clear`.
+
+.. code-block:: python
+
    queue.clear()
+
+This does the same thing as `~safir.asyncio.AsyncMultiQueue.close` for all existing readers, and then empties the queue and resets it so that new data can be added.
+New readers will see a fresh, empty queue.
 
 The type information for `~safir.asyncio.AsyncMultiQueue` can be any type.
 Note that the writer interface is fully synchronous.
@@ -34,7 +41,7 @@ A typical reader looks like this:
    async for item in queue:
        await do_something(item)
 
-This iterates over the full contents of the queue until `~safir.asyncio.AsyncMultiQueue.clear` is called by the writer.
+This iterates over the full contents of the queue until `~safir.asyncio.AsyncMultiQueue.close` or `~safir.asyncio.AsyncMultiQueue.clear` is called by the writer.
 
 Readers can also start at any position and specify a timeout.
 The timeout, if given, is the total length of time the iterator is allowed to run, not the time to wait for the next element.

--- a/docs/user-guide/asyncio-queue.rst
+++ b/docs/user-guide/asyncio-queue.rst
@@ -1,0 +1,51 @@
+#######################################
+Using the asyncio multiple-reader queue
+#######################################
+
+`~asyncio.Queue`, provided by the basic library, is an asyncio queue implementation, but the protocol it implements delivers each item in the queue to only one reader.
+In some cases, you may need behavior more like a publish/subscribe queue: multiple readers all see the full contents of the queue, independently.
+
+Safir provides the `~safir.asyncio.AsyncMultiQueue` data structure for this use case.
+Its API is somewhat inspired by that of `~asyncio.Queue`, but it is intended for use as an async iterator rather than by calling a ``get`` method.
+
+The writer should use the queue as follows:
+
+.. code-block:: python
+
+   from safir.asyncio import AsyncMultiQueue
+
+
+   queue = AsyncMultiQueue[str]()
+   queue.put("soemthing")
+   queue.put("else")
+
+   # Calling clear will deliver the contents of the queue to all readers
+   # and then tell them that the queue of data has ended so their
+   # iterators will stop.
+   queue.clear()
+
+The type information for `~safir.asyncio.AsyncMultiQueue` can be any type.
+Note that the writer interface is fully synchronous.
+
+A typical reader looks like this:
+
+.. code-block:: python
+
+   async for item in queue:
+       await do_something(item)
+
+This iterates over the full contents of the queue until ``clear`` is called by the writer.
+
+Readers can also start at any position and specify a timeout.
+The timeout, if given, is the total length of time the iterator is allowed to run, not the time to wait for the next element.
+
+.. code-block:: python
+
+   from datetime import timedelta
+
+
+   timeout = timedelta(seconds=5)
+   async for item in queue.aiter_from(4, timeout):
+       await do_something(item)
+
+This reader will ignore all elements until the fourth, and will raise `TimeoutError` after five seconds of total time in the iterator.

--- a/docs/user-guide/asyncio-queue.rst
+++ b/docs/user-guide/asyncio-queue.rst
@@ -34,7 +34,7 @@ A typical reader looks like this:
    async for item in queue:
        await do_something(item)
 
-This iterates over the full contents of the queue until ``clear`` is called by the writer.
+This iterates over the full contents of the queue until `~safir.asyncio.AsyncMultiQueue.clear` is called by the writer.
 
 Readers can also start at any position and specify a timeout.
 The timeout, if given, is the total length of time the iterator is allowed to run, not the time to wait for the next element.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -31,3 +31,4 @@ User guide
    slack-webhook
    github-apps/index
    click
+   asyncio-queue

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -3,13 +3,147 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine
+from datetime import timedelta
 from functools import wraps
-from typing import Any, TypeVar
+from types import EllipsisType
+from typing import Any, Generic, TypeVar
 
+from .datetime import current_datetime
+
+#: Type variable of objects being stored in `AsyncMultiQueue`.
 T = TypeVar("T")
 
-__all__ = ["run_with_asyncio"]
+__all__ = [
+    "AsyncMultiQueue",
+    "run_with_asyncio",
+    "T",
+]
+
+
+class AsyncMultiQueue(Generic[T]):
+    """An asyncio multiple reader, multiple writer queue.
+
+    Provides a generic queue for asyncio that supports multiple readers (via
+    async iterator) and multiple writers. Readers can start reading at any
+    time and will begin reading from the start of the queue. There is no
+    maximum size of the queue; new items will be added subject only to the
+    limits of available memory.
+
+    This data structure is not thread-safe. It uses only asyncio locking, not
+    thread-safe locking.
+
+    The ellipsis object (``...``) is used as a placeholder to indicate the end
+    of the queue, so cannot be pushed onto the queue.
+    """
+
+    def __init__(self) -> None:
+        self._contents: list[T | EllipsisType] = []
+        self._triggers: list[asyncio.Event] = []
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        """Return an async iterator over the queue."""
+        return self.aiter_from(0)
+
+    def aiter_from(
+        self, start: int, timeout: timedelta | None = None
+    ) -> AsyncIterator[T]:
+        """Return an async iterator over the queue.
+
+        Each call to this function returns a separate iterator over the same
+        underlying contents, and each iterator will be triggered separately.
+
+        Parameters
+        ----------
+        start
+            Starting position in the queue. This can be larger than the
+            current queue size, in which case no items are returned until the
+            queue passes the given starting position.
+        timeout
+            If given, total length of time for the iterator. This isn't the
+            timeout waiting for the next item; this is the total execution
+            time of the iterator.
+
+        Raises
+        ------
+        TimeoutError
+            Raised when the timeout is reached.
+        """
+        if timeout:
+            end_time = current_datetime(microseconds=True) + timeout
+        else:
+            end_time = None
+
+        # Grab a reference to the current contents so that the iterator
+        # detaches from the contents on clear.
+        contents = self._contents
+
+        # Add a trigger for this caller and make sure it's set if there are
+        # any existing contents.
+        trigger = asyncio.Event()
+        if contents:
+            trigger.set()
+        self._triggers.append(trigger)
+
+        # Construct the iteartor, which waits for the trigger and returns any
+        # new events until it sees the placeholder for the end of the queue
+        # (the ellipsis object).
+        async def iterator() -> AsyncIterator[T]:
+            position = start
+            try:
+                while True:
+                    trigger.clear()
+                    end = len(contents)
+                    if position < end:
+                        for item in contents[position:end]:
+                            if item is Ellipsis:
+                                return
+                            yield item
+                        position = end
+                    elif contents and contents[-1] is Ellipsis:
+                        return
+                    if end_time:
+                        now = current_datetime(microseconds=True)
+                        timeout_left = (end_time - now).total_seconds()
+                        async with asyncio.timeout(timeout_left):
+                            await trigger.wait()
+                    else:
+                        await trigger.wait()
+            finally:
+                self._triggers = [t for t in self._triggers if t != trigger]
+
+        return iterator()
+
+    def clear(self) -> None:
+        """Empty the contents of the queue.
+
+        Any existing readers will still see all items pushed to the queue
+        before the clear, but will become detached from the queue and will not
+        see any new events added after the clear.
+        """
+        contents = self._contents
+        triggers = self._triggers
+        self._contents = []
+        self._triggers = []
+        contents.append(Ellipsis)
+        for trigger in triggers:
+            trigger.set()
+
+    def put(self, item: T) -> None:
+        """Add an item to the queue.
+
+        Parameters
+        ----------
+        item
+           Item to add.
+        """
+        self._contents.append(item)
+        for trigger in self._triggers:
+            trigger.set()
+
+    def qsize(self) -> int:
+        """Return the number of items currently in the queue."""
+        return len(self._contents)
 
 
 def run_with_asyncio(

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -52,7 +52,7 @@ class AsyncMultiQueue(Generic[T]):
 
     @property
     def finished(self) -> bool:
-        """Whether `end` has been called on the queue.
+        """Whether `close` has been called on the queue.
 
         If this property is `True`, the contents of the queue are finalized
         and no new items will be added unless the queue is cleared with
@@ -143,14 +143,14 @@ class AsyncMultiQueue(Generic[T]):
             for trigger in triggers:
                 trigger.set()
 
-    def end(self) -> None:
+    def close(self) -> None:
         """Mark the end of the queue data.
 
         Similar to `clear` in that any existing readers of the queue will see
         the end of the iterator, but the data will not be deleted and new
         readers can still read all of the data in the queue.
 
-        After `end` is called, `clear` must be called before any subsequent
+        After `close` is called, `clear` must be called before any subsequent
         `put`.
         """
         self._contents.append(Ellipsis)

--- a/src/safir/asyncio.py
+++ b/src/safir/asyncio.py
@@ -78,14 +78,11 @@ class AsyncMultiQueue(Generic[T]):
         # detaches from the contents on clear.
         contents = self._contents
 
-        # Add a trigger for this caller and make sure it's set if there are
-        # any existing contents.
+        # Add a trigger for this caller.
         trigger = asyncio.Event()
-        if contents:
-            trigger.set()
         self._triggers.append(trigger)
 
-        # Construct the iteartor, which waits for the trigger and returns any
+        # Construct the iterator, which waits for the trigger and returns any
         # new events until it sees the placeholder for the end of the queue
         # (the ellipsis object).
         async def iterator() -> AsyncIterator[T]:

--- a/tests/asyncio_test.py
+++ b/tests/asyncio_test.py
@@ -2,7 +2,50 @@
 
 from __future__ import annotations
 
-from safir.asyncio import run_with_asyncio
+import asyncio
+
+import pytest
+
+from safir.asyncio import AsyncMultiQueue, run_with_asyncio
+
+
+@pytest.mark.asyncio
+async def test_async_multi_queue() -> None:
+    queue = AsyncMultiQueue[str]()
+    queue.put("one")
+    queue.put("two")
+    assert queue.qsize() == 2
+
+    async def watcher(position: int) -> list[str]:
+        return [s async for s in queue.aiter_from(position)]
+
+    async def watcher_iter() -> list[str]:
+        return [s async for s in queue]
+
+    start_task = asyncio.create_task(watcher_iter())
+    one_task = asyncio.create_task(watcher(1))
+    current_task = asyncio.create_task(watcher(queue.qsize()))
+    future_task = asyncio.create_task(watcher(3))
+    way_future_task = asyncio.create_task(watcher(10))
+
+    await asyncio.sleep(0.1)
+    queue.put("three")
+    await asyncio.sleep(0.1)
+    queue.put("four")
+    await asyncio.sleep(0.1)
+    queue.clear()
+    assert queue.qsize() == 0
+
+    after_clear_task = asyncio.create_task(watcher_iter())
+    await asyncio.sleep(0.1)
+    queue.clear()
+
+    assert await start_task == ["one", "two", "three", "four"]
+    assert await one_task == ["two", "three", "four"]
+    assert await current_task == ["three", "four"]
+    assert await future_task == ["four"]
+    assert await way_future_task == []
+    assert await after_clear_task == []
 
 
 def test_run_with_asyncio() -> None:

--- a/tests/asyncio_test.py
+++ b/tests/asyncio_test.py
@@ -50,7 +50,7 @@ async def test_async_multi_queue() -> None:
     after_clear_task = asyncio.create_task(watcher_iter())
     await asyncio.sleep(0.1)
     queue.put("something")
-    queue.end()
+    queue.close()
     assert queue.finished
     assert queue.qsize() == 1
 


### PR DESCRIPTION
Add an asyncio multiple writer, multiple reader queue, and convert the Kubernetes mock to use it instead of implementing its own. This data structure is also used in the JupyterHub REST spawner and in the Nublado lab controller.