### PR TITLE
DM-40691: Add list_namespaced_custom_object to mock

### DIFF
--- a/changelog.d/20230908_143247_rra_DM_40691.md
+++ b/changelog.d/20230908_143247_rra_DM_40691.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add `list_namespaced_custom_object` with watch support to the Kubernetes mock.


### PR DESCRIPTION
Add support for list_namespaced_custom_object, including watch support, to the Kubernetes mock. Update the resource version field of custom objects appropriately.