### PR TITLE
DM-40691: Maintain more resource versions in Kubernetes mock

### DIFF
--- a/changelog.d/20230908_150940_rra_DM_40691.md
+++ b/changelog.d/20230908_150940_rra_DM_40691.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The Kubernetes mock now correctly maintains the resource version of `Ingress`, `Job`, and `Service` objects, since they support watches which rely on resource versions.


### PR DESCRIPTION
Ingress, Job, and Service objects previously didn't correctly maintain resource versions on all object updates, but they support watches which in turn rely on resource versions. Add the necessary resource version updates.