### PR TITLE
DM-40691: Make Pod creation from a Job more correct in mock

### DIFF
--- a/changelog.d/20230908_152325_rra_DM_40691_queue.md
+++ b/changelog.d/20230908_152325_rra_DM_40691_queue.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When creating a `Pod` from a `Job` in the Kubernetes mock using `generateName`, randomize the `Pod` name like Kubernetes does rather than using a fixed name. This forces tests to scan correctly for pods associated with a job. If the `Pod` `name` or `generateName` was explicitly configured in the `Job` template, honor it.


### PR DESCRIPTION
Randomize the Pod name in a similar way that Kubernetes does when the default generateName behavior is used. If an explicit name was set in the pod template in the Job, use that name; don't replace it with a generated name. Honor generateName set in the pod template in the Job.