### PR TITLE
DM-40691: Add watch support for namespaces

### DIFF
--- a/changelog.d/20230912_145508_rra_DM_40691.md
+++ b/changelog.d/20230912_145508_rra_DM_40691.md
@@ -1,0 +1,7 @@
+### New features
+
+- Add watch, field selector, and label selector support to `list_namespace` in the Kubernetes mock.
+
+### Bug fixes
+
+- `read_namespace` and `list_namespace` in the Kubernetes mock now only return namespace objects that have been explicitly created, not implicit namespaces created by creating another object without making a namespace first. This more closely matches the behavior of Kubernetes while still making it easy to use the mock in a test environment simulating a pre-existing namespace.


### PR DESCRIPTION
Add watch, field selector, and label selector support to list_namespace in the Kubernetes mock.

read_namespace and list_namespace in the Kubernetes mock now only return namespace objects that have been explicitly created, not implicit namespaces created by creating another object without making a namespace first. This more closely matches the behavior of Kubernetes while still making it easy to use the mock in a test environment simulating a pre-existing namespace.

Fix the documentation for label_selector in list_* functions to reflect that it is applied to the regular list return, not just the watch.