### PR TITLE
DM-398710: Remove GitHubAppClientFactory.create_app_client

### DIFF
--- a/changelog.d/20230914_173515_jsick_DM_39710_remove_app_factory.md
+++ b/changelog.d/20230914_173515_jsick_DM_39710_remove_app_factory.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Remove the `GitHubAppClientFactory.create_app_client` method, which does not work with the Gidgethub API. Instead, the documentation shows how to create a JWT with the `GitHubAppClientFactory` and pass it with requests.

--- a/docs/user-guide/github-apps/create-a-github-client.rst
+++ b/docs/user-guide/github-apps/create-a-github-client.rst
@@ -69,20 +69,29 @@ Authenticating as the app
 Your app can authenticate to GitHub in two modes: as the *app itself*, or as an *installation* of the app.
 Authenticating as the GitHub App enables your app to access information about the app itself, such as its installations.
 
+To do this, get the app's JWT and use it with an GitHub client requests:
+
 .. code-block:: python
 
-   app_client = github_client_factory.create_app_client()
+   client = github_client_factory.create_anonymous_client()
+   jwt = github_client_factory.get_app_jwt()
+
+Example of using the JWT to get the app's installations:
+
+.. code-block:: python
+
+   data = await client.getitem("/app/installations", jwt=jwt)
 
 Authenticating as the app installation
 ======================================
 
 To authenticate as an installation of the app, you need to know the installation ID.
-Dependening on the scenario, there are multiple ways of getting the installation ID.
+Depending on the scenario, there are multiple ways of getting the installation ID.
 
 In a webhook handler
 --------------------
 
-If your app recieves a webhook from GitHub, the installation ID will be included in the payload (as the ``installation.id`` field, see the `~safir.github.webhooks.GitHubAppInstallationModel`).
+If your app receives a webhook from GitHub, the installation ID will be included in the payload (as the ``installation.id`` field, see the `~safir.github.webhooks.GitHubAppInstallationModel`).
 
 .. code-block:: python
 

--- a/src/safir/github/_client.py
+++ b/src/safir/github/_client.py
@@ -61,16 +61,6 @@ class GitHubAppClientFactory:
         """
         return self._create_client()
 
-    def create_app_client(self) -> GitHubAPI:
-        """Create a client authenticated as the GitHub App.
-
-        Returns
-        -------
-        gidgethub.httpx.GitHubAPI
-            The app client.
-        """
-        return self._create_client(oauth_token=self.get_app_jwt())
-
     async def create_installation_client(
         self, installation_id: str
     ) -> GitHubAPI:


### PR DESCRIPTION
This method was mistakenly added with sufficient testing and never worked. The Gidgethub API cannot cache an app JWT with its current API. The documentation now features the correct workflow, which requires manually obtaining the JWT and passing it with each release.

Since this is technically a breaking change, it should be included with the next major release. However, since the API was never usable, there shouldn't be any issue removing it.