### PR TITLE
DM-23878: Allow log level enum with any case

### DIFF
--- a/changelog.d/20231003_135049_rra_DM_23878.md
+++ b/changelog.d/20231003_135049_rra_DM_23878.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow the `safir.logging.LogLevel` enum to be created from strings of any case, which will allow the logging level to be specified with any case for Safir applications that use Pydantic to validate the field.

--- a/src/safir/logging.py
+++ b/src/safir/logging.py
@@ -7,7 +7,7 @@ import logging.config
 import re
 import sys
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 
 import structlog
 from structlog.stdlib import add_log_level
@@ -48,13 +48,28 @@ class Profile(Enum):
 
 
 class LogLevel(Enum):
-    """Python logging level."""
+    """Python logging level.
+
+    Any case variation is accepted when converting a string to an enum value
+    via the class constructor.
+    """
 
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARNING = "WARNING"
     ERROR = "ERROR"
     CRITICAL = "CRITICAL"
+
+    @classmethod
+    def _missing_(cls, value: Any) -> Self | None:
+        """Allow strings in any case to be used to create the enum."""
+        if not isinstance(value, str):
+            return None
+        value = value.upper()
+        for member in cls:
+            if member.value == value:
+                return member
+        return None
 
 
 def add_log_severity(


### PR DESCRIPTION
When configuring a FastAPI application with debug logging, I used "debug" instead of "DEBUG" in the configuration and was then annoyed that the server didn't start with an error. The function call supported a string with any case, but the Pydantic model we use to validate most configurations required uppercase because it relied on the enum to do the validation.

Implement a `_missing_` method for the LogLevel enum that converts strings in any case to the expected uppercase, which allows Pydantic validation of models to work with any case of the log level and still validates and returns the correct log level.