### PR TITLE
DM-41630: Update development Redis dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ dev = [
     "psycopg2",
     "pytest",
     "pytest-asyncio",
+    "redis>=5,<6",
     "respx",
     "scriv",
     "sqlalchemy[mypy]",
-    "types-redis",
     "uvicorn",
     # documentation
     "documenteer[guide]>=1.0.0a7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ async def redis_client() -> AsyncIterator[redis.Redis]:
 
     This fixture connects to the Redis server that runs via tox-docker.
     """
-    client: redis.Redis = redis.Redis(host="localhost", port=6379, db=0)
+    client = redis.Redis(host="localhost", port=6379, db=0)
     yield client
 
-    await client.close()
+    await client.aclose()


### PR DESCRIPTION
redis-py 5.0.0 changed the async close method from close to aclose, and types-redis is no longer accurate for the library. Drop the types-redis development dependency, add a versioned development dependency, and use aclose instead of close to avoid a warning when running the test suite.