### PR TITLE
DM-41630: Convert to FastAPI lifespan functions

### DIFF
--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -19,21 +19,26 @@ Quick start
 Dependency set up and configuration
 -----------------------------------
 
-In your application's FastAPI setup module, typically :file:`main.py`, you need to initialize `safir.dependencies.arq.ArqDependency` during the start up event:
+In your application's FastAPI setup module, typically :file:`main.py`, you need to initialize `safir.dependencies.arq.ArqDependency` during your lifespan function.
 
 .. code-block:: python
+
+    from collections.abc import AsyncIterator
+    from contextlib import asynccontextmanager
 
     from fastapi import Depends, FastAPI
     from safir.dependencies.arq import arq_dependency
 
-    app = FastAPI()
 
-
-    @app.on_event("startup")
-    async def startup() -> None:
+    @asynccontextmanager
+    def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await arq_dependency.initialize(
             mode=config.arq_mode, redis_settings=config.arq_redis_settings
         )
+        yield
+
+
+    app = FastAPI(lifespan=lifespan)
 
 The ``mode`` parameter for `safir.dependencies.arq.ArqDependency.initialize` takes `ArqMode` enum values of either ``"production"`` or ``"test"``. The ``"production"`` mode configures a real arq_ queue backed by Redis, whereas ``"test"`` configures a mock version of the arq_ queue.
 

--- a/docs/user-guide/http-client.rst
+++ b/docs/user-guide/http-client.rst
@@ -11,19 +11,23 @@ Setting up the httpx.AsyncClient
 The ``httpx.AsyncClient`` will be dyanmically created during application startup.
 Nothing further is needed apart from importing the dependency.
 However, it must be closed during application shutdown or a warning will be generated.
-
-To do this, add a shutdown hook to your application:
+This is normally done during the lifespan function for the FastAPI app.
 
 .. code-block:: python
 
+   from collections.abc import AsyncIterator
+   from contextlib import asynccontextmanager
+
    from safir.dependencies.http_client import http_client_dependency
 
-   app = FastAPI()
 
-
-   @app.on_event("shutdown")
-   async def shutdown_event() -> None:
+   @asynccontextmanager
+   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+       yield
        await http_client_dependency.aclose()
+
+
+   app = FastAPI(lifespan=lifespan)
 
 You can add this line to an existing shutdown hook if you already have one.
 

--- a/docs/user-guide/kubernetes.rst
+++ b/docs/user-guide/kubernetes.rst
@@ -24,12 +24,17 @@ For example:
 
 .. code-block:: python
 
+   from collections.abc import AsyncIterator
+   from contextlib import asynccontextmanager
+
+   from fastapi import FastAPI
    from safir.kubernetes import initialize_kubernetes
 
 
-   @app.on_event("startup")
-   async def startup_event() -> None:
+   @asynccontextmanager
+   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
        await initialize_kubernetes()
+       yield
 
 Testing with mock Kubernetes
 ============================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ db = [
 dev = [
     "asgi-lifespan",
     "coverage[toml]",
+    "fastapi>=0.93.0",
     "flake8",
     "mypy",
     "pre-commit",

--- a/src/safir/dependencies/arq.py
+++ b/src/safir/dependencies/arq.py
@@ -43,22 +43,27 @@ class ArqDependency:
         --------
         .. code-block:: python
 
+           from collections.abc import AsyncIterator
+           from contextlib import asynccontextmanager
+
            from fastapi import Depends, FastAPI
            from safir.arq import ArqMode, ArqQueue
            from safir.dependencies.arq import arq_dependency
 
-           app = FastAPI()
 
-
-           @app.on_event("startup")
-           async def startup() -> None:
+           @asynccontextmanager
+           async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                await arq_dependency.initialize(mode=ArqMode.test)
+               yield
+
+
+           app = FastAPI()
 
 
            @app.post("/")
            async def post_job(
                arq_queue: ArqQueue = Depends(arq_dependency),
-           ) -> Dict[str, Any]:
+           ) -> dict[str, Any]:
                job = await arq_queue.enqueue("test_task", "hello", an_int=42)
                return {"job_id": job.id}
         """

--- a/src/safir/dependencies/http_client.py
+++ b/src/safir/dependencies/http_client.py
@@ -27,14 +27,24 @@ class HTTPClientDependency:
 
     Notes
     -----
-    The application must call ``http_client_dependency.aclose()`` as part of a
-    shutdown hook:
+    The application must call ``http_client_dependency.aclose()`` in the
+    application lifespan hook:
 
     .. code-block:: python
 
-       @app.on_event("shutdown")
-       async def shutdown_event() -> None:
+       from collections.abc import AsyncIterator
+       from contextlib import asynccontextmanager
+
+       from fastapi import FastAPI
+
+
+       @asynccontextmanager
+       async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+           yield
            await http_client_dependency.aclose()
+
+
+       app = FastAPI(lifespan=lifespan)
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
As of FastAPI 0.93.0, FastAPI supports a lifespan async context manager to do startup and shutdown. The part before the yield is run during application startup and the part after the yield is run during application shutdown. The older on_event annotations are now deprecated.

Add a development dependency on FastAPI 0.93.0 and change the test suite uses of on_event annotations to lifespan functions. Update all of the documentation to use the lifespan function instead of on_event handlers.

This change does not bump the Safir FastAPI dependency because Safir's own code still works fine with either method.