### PR TITLE
DM-41708: Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20231114_164421_rra_DM_41708.md
+++ b/changelog.d/20231114_164421_rra_DM_41708.md
@@ -1,0 +1,3 @@
+### New features
+
+- Safir now supports Python 3.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",


### PR DESCRIPTION
Add Python 3.12 to the test matrix and advertise that it is supported.