### PR TITLE
DM-41708: Add more mocks for Kubernetes PVCs

### DIFF
--- a/changelog.d/20231114_171851_rra_DM_41708a.md
+++ b/changelog.d/20231114_171851_rra_DM_41708a.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add delete, list, and watch support for persistent volume claims to the Kubernetes mock.


### PR DESCRIPTION
Add delete, list, and watch support for persistent volume claims to the Kubernetes mock. Fix a few comments on Kubernetes mock methods.