### PR TITLE
DM-41708: Fix Pod creation from Job in Kubernetes mock

### DIFF
--- a/changelog.d/20231116_110515_rra_DM_41708a.md
+++ b/changelog.d/20231116_110515_rra_DM_41708a.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Avoid reusing the same metadata object when creating a `Pod` from a `Job`. Previous versions modified the `spec` part of the `Job` when adding additional metadata to the child `Pod`.


### PR DESCRIPTION
Avoid reusing the same metadata object when creating a Pod from a Job. Previous versions modified the spec part of the Job when adding additional metadata to the child Pod.