### PR TITLE
DM-41820: Fix annotations on Pod created from Job

### DIFF
--- a/src/safir/testing/kubernetes.py
+++ b/src/safir/testing/kubernetes.py
@@ -1357,7 +1357,7 @@ class MockKubernetesApi:
             if source.labels:
                 metadata.labels = source.labels.copy()
             if source.annotations:
-                metadata.annnotations = source.annotations.copy()
+                metadata.annotations = source.annotations.copy()
         pod = V1Pod(metadata=metadata, spec=body.spec.template.spec)
         if not pod.metadata.name:
             if not pod.metadata.generate_name:


### PR DESCRIPTION
Due to a typo, the annotations from the spec in a Job resource were not being copied to the created Pod in the Kubernetes mock. This bug was introduced in 5.0.0a4.