### PR TITLE
DM-41998: Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20231205_093902_rra_DM_41998.md
+++ b/changelog.d/20231205_093902_rra_DM_41998.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Safir is now tested with Python 3.12 as well as Python 3.11.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
@@ -134,10 +135,17 @@ exclude = '''
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 filterwarnings = [
-    "ignore:'cgi' is deprecated:DeprecationWarning:google.cloud.storage.blob",
     # Google modules call a deprecated pkg_resources API.
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
+    # Google modules use PyType_Spec in a deprecated way.
+    "ignore:Type google\\..*metaclass.* custom tp_new:DeprecationWarning",
+    # dateutil uses a deprecated datetime function.
+    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.*",
+    # The point of this test is to test handling of datetime-naive UTC
+    # objects, which is what the deprecation warning is about. We want to
+    # continue doing this until the support has been removed entirely.
+    "ignore:datetime.datetime.utcnow:DeprecationWarning:tests.pydantic_test",
 ]
 python_files = [
     "tests/*.py",


### PR DESCRIPTION
Add Python 3.12 to the test matrix and declare support for it. This required adding some more ignore rules for deprecations in third-party modules, and one deprecation that affects a test case that is explicitly testing deprecated behavior.