### PR TITLE
DM-42527: Rewrite middleware as pure ASGI middleware

### DIFF
--- a/changelog.d/20240116_164958_rra_DM_42527.md
+++ b/changelog.d/20240116_164958_rra_DM_42527.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Rewrite `CaseInsensitiveQueryMiddleware` and `XForwardedMiddleware` as pure ASGI middleware rather than using the Starlette `BaseHTTPMiddleware` class. The latter seems to be behind some poor error reporting of application exceptions, has caused problems in the past due to its complexity, and is not used internally by Starlette middleware.

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from copy import copy
 from ipaddress import _BaseAddress, _BaseNetwork, ip_address
 
-from fastapi import FastAPI, Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 __all__ = ["XForwardedMiddleware"]
 
 
-class XForwardedMiddleware(BaseHTTPMiddleware):
-    """Middleware to update the request based on ``X-Forwarded-For``.
+class XForwardedMiddleware:
+    """ASGI middleware to update the request based on ``X-Forwarded-For``.
 
     The remote IP address will be replaced with the right-most IP address in
     ``X-Forwarded-For`` that is not contained within one of the trusted
@@ -20,60 +20,47 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
 
     If ``X-Forwarded-For`` is found and ``X-Forwarded-Proto`` is also present,
     the corresponding entry of ``X-Forwarded-Proto`` is used to replace the
-    scheme in the request scope.  If ``X-Forwarded-Proto`` only has one entry
+    scheme in the request scope. If ``X-Forwarded-Proto`` only has one entry
     (ingress-nginx has this behavior), that one entry will become the new
     scheme in the request scope.
 
     The contents of ``X-Forwarded-Host`` will be stored as ``forwarded_host``
-    in the request state if it and ``X-Forwarded-For`` are present.  Normally
+    in the request state if it and ``X-Forwarded-For`` are present. Normally
     this is not needed since NGINX will pass the original ``Host`` header
     without modification.
 
     Parameters
     ----------
     proxies
-        The networks of the trusted proxies.  If not specified, defaults to
-        the empty list, which means only the immediately upstream proxy will
-        be trusted.
+        The networks of the trusted proxies. If not specified, defaults to the
+        empty list, which means only the immediately upstream proxy will be
+        trusted.
     """
 
     def __init__(
-        self, app: FastAPI, *, proxies: list[_BaseNetwork] | None = None
+        self, app: ASGIApp, *, proxies: list[_BaseNetwork] | None = None
     ) -> None:
-        super().__init__(app)
-        if proxies:
-            self.proxies = proxies
-        else:
-            self.proxies = []
+        self._app = app
+        self._proxies = proxies if proxies else []
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        """Middleware to update the request based on ``X-Forwarded-For``.
-
-        Parameters
-        ----------
-        request
-            The incoming request.
-        call_next
-            The next step in the processing stack.
-
-        Returns
-        -------
-        ``fastapi.Response``
-            The response with additional information about proxy headers.
-        """
-        forwarded_for = list(reversed(self._get_forwarded_for(request)))
+    async def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+        scope = copy(scope)
+        scope.setdefault("state", {})
+        headers = Headers(scope=scope)
+        forwarded_for = list(reversed(self._get_forwarded_for(headers)))
         if not forwarded_for:
-            request.state.forwarded_host = None
-            request.state.forwarded_proto = None
-            return await call_next(request)
+            scope["state"]["forwarded_host"] = None
+            await self._app(scope, receive, send)
+            return
 
         client = None
         for n, ip in enumerate(forwarded_for):
-            if any(ip in network for network in self.proxies):
+            if any(ip in network for network in self._proxies):
                 continue
             client = str(ip)
             index = n
@@ -85,45 +72,45 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
             client = str(forwarded_for[-1])
             index = -1
 
-        # Update the request's understanding of the client IP.  This uses an
-        # undocumented interface; hopefully it will keep working.
-        if request.client:
-            request.scope["client"] = (client, request.client.port)
+        # Update the request's understanding of the client IP.
+        if scope.get("client"):
+            scope["client"] = (client, scope["client"][1])
         else:
-            request.scope["client"] = (client, None)
+            scope["client"] = (client, None)
 
         # Ideally this should take the scheme corresponding to the entry in
         # X-Forwarded-For that was chosen, but some proxies (the Kubernetes
         # NGINX ingress, for example) only retain one element in
-        # X-Forwarded-Proto.  In that case, use what we have.
-        proto = list(reversed(self._get_forwarded_proto(request)))
+        # X-Forwarded-Proto. In that case, use what we have.
+        proto = list(reversed(self._get_forwarded_proto(headers)))
         if proto:
             if index >= len(proto):
                 index = -1
-            request.scope["scheme"] = proto[index]
+            scope["scheme"] = proto[index]
 
-        # Rather than one entry per hop, NGINX seems to add only a single
-        # X-Forwarded-Host header with the original hostname.
-        request.state.forwarded_host = self._get_forwarded_host(request)
+        # Record what appears to be the client host for logging purposes.
+        scope["state"]["forwarded_host"] = self._get_forwarded_host(headers)
 
-        return await call_next(request)
+        # Perform the rest of the request processing.
+        await self._app(scope, receive, send)
+        return
 
-    def _get_forwarded_for(self, request: Request) -> list[_BaseAddress]:
+    def _get_forwarded_for(self, headers: Headers) -> list[_BaseAddress]:
         """Retrieve the ``X-Forwarded-For`` entries from the request.
 
         Parameters
         ----------
-        request
-            The incoming request.
+        scope
+            Request headers.
 
         Returns
         -------
         list of ipaddress._BaseAddress
-            The list of addresses found in the header.  If there are multiple
+            The list of addresses found in the header. If there are multiple
             ``X-Forwarded-For`` headers, we don't know which one is correct,
             so act as if there are no headers.
         """
-        forwarded_for_str = request.headers.getlist("X-Forwarded-For")
+        forwarded_for_str = headers.getlist("X-Forwarded-For")
         if not forwarded_for_str or len(forwarded_for_str) > 1:
             return []
         return [
@@ -132,43 +119,43 @@ class XForwardedMiddleware(BaseHTTPMiddleware):
             if addr
         ]
 
-    def _get_forwarded_host(self, request: Request) -> str | None:
+    def _get_forwarded_host(self, headers: Headers) -> str | None:
         """Retrieve the ``X-Forwarded-Host`` header.
 
         Parameters
         ----------
-        request
-            The incoming request.
+        headers
+            Request headers.
 
         Returns
         -------
         str
             The value of the ``X-Forwarded-Host`` header, if present and if
-            there is only one header.  If there are multiple
+            there is only one header. If there are multiple
             ``X-Forwarded-Host`` headers, we don't know which one is correct,
             so act as if there are no headers.
         """
-        forwarded_host = request.headers.getlist("X-Forwarded-Host")
+        forwarded_host = headers.getlist("X-Forwarded-Host")
         if not forwarded_host or len(forwarded_host) > 1:
             return None
         return forwarded_host[0].strip()
 
-    def _get_forwarded_proto(self, request: Request) -> list[str]:
+    def _get_forwarded_proto(self, headers: Headers) -> list[str]:
         """Retrieve the ``X-Forwarded-Proto`` entries from the request.
 
         Parameters
         ----------
-        request
-            The incoming request.
+        headers
+            Request headers.
 
         Returns
         -------
         list of str
-            The list of schemes found in the header.  If there are multiple
+            The list of schemes found in the header. If there are multiple
             ``X-Forwarded-Proto`` headers, we don't know which one is correct,
             so act as if there are no headers.
         """
-        forwarded_proto_str = request.headers.getlist("X-Forwarded-Proto")
+        forwarded_proto_str = headers.getlist("X-Forwarded-Proto")
         if not forwarded_proto_str or len(forwarded_proto_str) > 1:
             return []
         return [p.strip() for p in forwarded_proto_str[0].split(",")]

--- a/tests/middleware/x_forwarded_test.py
+++ b/tests/middleware/x_forwarded_test.py
@@ -7,6 +7,7 @@ from ipaddress import _BaseNetwork, ip_network
 import pytest
 from fastapi import FastAPI, Request
 from httpx import AsyncClient
+from starlette.datastructures import Headers
 
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
@@ -159,7 +160,7 @@ async def test_too_many_headers() -> None:
     end.  Instead, test by generating a mock request and then calling the
     underling middleware functions directly.
     """
-    state = {
+    scope = {
         "type": "http",
         "headers": [
             ("X-Forwarded-For", "10.10.10.10"),
@@ -170,9 +171,9 @@ async def test_too_many_headers() -> None:
             ("X-Forwarded-Host", "example.com"),
         ],
     }
-    request = Request(state)
+    headers = Headers(scope=scope)
     app = FastAPI()
     middleware = XForwardedMiddleware(app, proxies=[ip_network("10.0.0.0/8")])
-    assert middleware._get_forwarded_for(request) == []
-    assert middleware._get_forwarded_proto(request) == []
-    assert not middleware._get_forwarded_host(request)
+    assert middleware._get_forwarded_for(headers) == []
+    assert middleware._get_forwarded_proto(headers) == []
+    assert not middleware._get_forwarded_host(headers)


### PR DESCRIPTION
Rewrite CaseInsensitiveQueryMiddleware and XForwardedMiddleware as pure ASGI middleware rather than using the Starlette BaseHTTPMiddleware class. The latter seems to be behind some poor error reporting of application exceptions, has caused problems in the past due to its complexity, and is not used internally by Starlette middleware.