### PR TITLE
DM-42190: Add gafaelfawr delegated token FastAPI dependency

### DIFF
--- a/changelog.d/20240116_094526_david.irving.md
+++ b/changelog.d/20240116_094526_david.irving.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Add a FastAPI dependency for retrieving a Gafaelfawr delegated token from the request headers: `safir.dependencies.gafaelfawr.auth_delegated_token_dependency`.

--- a/src/safir/dependencies/gafaelfawr.py
+++ b/src/safir/dependencies/gafaelfawr.py
@@ -6,6 +6,7 @@ from structlog.stdlib import BoundLogger
 from .logger import logger_dependency
 
 __all__ = [
+    "auth_delegated_token_dependency",
     "auth_dependency",
     "auth_logger_dependency",
 ]
@@ -21,6 +22,20 @@ async def auth_dependency(
     the Gafaelfawr ``auth_request`` NGINX subhandler.
     """
     return x_auth_request_user
+
+
+async def auth_delegated_token_dependency(
+    x_auth_request_token: str = Header(..., include_in_schema=False)
+) -> str:
+    """Retrieve Gafaelfawr delegated token from HTTP headers.
+
+    Intended for use with applications protected by Gafaelfawr, this retrieves
+    a delegated token from headers added to the incoming request by the
+    Gafaelfawr ``auth_request`` NGINX subhandler.  The delegated token can
+    be used to make requests to other services on the user's behalf, see
+    https://gafaelfawr.lsst.io/user-guide/gafaelfawringress.html#requesting-delegated-tokens
+    """
+    return x_auth_request_token
 
 
 async def auth_logger_dependency(


### PR DESCRIPTION
Added a FastAPI dependency for retrieving a Gafaelfawr delegated token from the request headers.  This will be used by services consuming client/server Butler, since it needs the delegated token to determine the user's authorization to access a repository.