### PR TITLE
DM-43288: Ensure per-request database sessions are closed

### DIFF
--- a/changelog.d/20240312_174906_rra_DM_43288.md
+++ b/changelog.d/20240312_174906_rra_DM_43288.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Ensure that per-request database sessions provided by `db_session_dependency` are cleaned up even if the request aborts with an uncaught exception.

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -50,13 +50,14 @@ class DatabaseSessionDependency:
         """
         if not self._session:
             raise RuntimeError("db_session_dependency not initialized")
-        yield self._session
-
-        # Following the recommendations in the SQLAlchemy documentation, each
-        # session is scoped to a single web request.  However, this all uses
-        # the same async_scoped_session object, so should share an underlying
-        # engine and connection pool.
-        await self._session.remove()
+        try:
+            yield self._session
+        finally:
+            # Following the recommendations in the SQLAlchemy documentation,
+            # each session is scoped to a single web request. However, this
+            # all uses the same async_scoped_session object, so should share
+            # an underlying engine and connection pool.
+            await self._session.remove()
 
     async def aclose(self) -> None:
         """Shut down the database engine."""


### PR DESCRIPTION
In the db_session_dependency FastAPI dependency, do database session cleanup in a finally block. This will hopefully ensure that the sessions are cleaned up even on uncaught exceptions, which in turn fixes warnings in test cases in other packages.