### PR TITLE
DM-44444: Allow database passwords to be SecretStrs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,12 +45,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Temporarily pin requests because 2.32.0 breaks docker 6.1.3.
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "py,typing"
-          tox-plugins: "tox-docker"
+          tox-plugins: "tox-docker 'requests<2.32.0'"
 
   docs:
 

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ clean:
 	rm -rf docs/_build
 	rm -rf docs/api
 
+# Temporarily pin requests because 2.32.0 breaks docker 6.1.3.
 .PHONY: init
 init:
-	pip install --upgrade pip tox tox-docker pre-commit
+	pip install --upgrade pip tox tox-docker pre-commit 'requests<2.32.0'
 	pip install --upgrade -e ".[arq,db,dev,gcs,kubernetes]"
 	pre-commit install
 	rm -rf .tox

--- a/changelog.d/20240520_163147_rra_DM_44444.md
+++ b/changelog.d/20240520_163147_rra_DM_44444.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow the database password to be passed to `create_database_engine` and `create_sync_session` as a Pydantic `SecretStr`.

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -70,6 +70,7 @@ For applications using `Click`_ (the recommended way to implement a command-line
        await engine.dispose()
 
 This code assumes that ``main`` is the Click entry point and ``.config`` provides a ``config`` object that contains the settings for the application, including the database URL and password as well as the normal Safir configuration settings.
+The database password may be a ``pydantic.SecretStr``, a `str`, or `None` if no password is required by the database.
 
 If it receives a connection error from the database, Safir will attempt the initialization five times, two seconds apart, to allow time for networking or a database proxy to start.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
     "sqlalchemy[mypy]",
     "uvicorn",
     # documentation
-    "documenteer[guide]>=1.0.0a7",
+    "documenteer[guide]>=1",
     "autodoc_pydantic",
 ]
 gcs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dev = [
     "asgi-lifespan",
     "coverage[toml]",
     "fastapi>=0.93.0",
-    "flake8",
     "mypy",
     "pre-commit",
     "psycopg2",


### PR DESCRIPTION
When initializing a database engine with create_database_engine or create_sync_session, allow the database password to be a SecretStr instead of a str. This simplifies the call for applications that use Pydantic with SecretStr for secrets.

Fix some places where development dependencies were out of date, and pin requests since the latest version breaks the docker library.