### PR TITLE
DM-44444: Update to latest tox-docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,13 +45,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Temporarily pin requests because 2.32.0 breaks docker 6.1.3.
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "py,typing"
-          tox-plugins: "tox-docker 'requests<2.32.0'"
+          tox-plugins: "tox-docker"
 
   docs:
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,9 @@ clean:
 	rm -rf docs/_build
 	rm -rf docs/api
 
-# Temporarily pin requests because 2.32.0 breaks docker 6.1.3.
 .PHONY: init
 init:
-	pip install --upgrade pip tox tox-docker pre-commit 'requests<2.32.0'
+	pip install --upgrade pip tox tox-docker pre-commit
 	pip install --upgrade -e ".[arq,db,dev,gcs,kubernetes]"
 	pre-commit install
 	rm -rf .tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncIterator, Iterator
 from datetime import timedelta
 
@@ -13,6 +14,14 @@ import respx
 from safir.testing.gcs import MockStorageClient, patch_google_storage
 from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
+
+
+@pytest.fixture
+def database_url() -> str:
+    """Dynamically construct the test database URL from tox-docker envvars."""
+    host = os.environ["POSTGRES_HOST"]
+    port = os.environ["POSTGRES_5432_TCP_PORT"]
+    return f"postgresql://safir@{host}:{port}/safir"
 
 
 @pytest.fixture
@@ -38,7 +47,9 @@ async def redis_client() -> AsyncIterator[redis.Redis]:
 
     This fixture connects to the Redis server that runs via tox-docker.
     """
-    client = redis.Redis(host="localhost", port=6379, db=0)
+    host = os.environ["REDIS_HOST"]
+    port = os.environ["REDIS_6379_TCP_PORT"]
+    client = redis.Redis(host=host, port=int(port), db=0)
     yield client
 
     await client.aclose()

--- a/tests/dependencies/db_session_test.py
+++ b/tests/dependencies/db_session_test.py
@@ -21,7 +21,6 @@ from safir.database import (
 )
 from safir.dependencies.db_session import db_session_dependency
 
-TEST_DATABASE_URL = os.environ["TEST_DATABASE_URL"]
 TEST_DATABASE_PASSWORD = os.getenv("TEST_DATABASE_PASSWORD")
 
 Base = declarative_base()
@@ -36,13 +35,13 @@ class User(Base):
 
 
 @pytest.mark.asyncio
-async def test_session() -> None:
+async def test_session(database_url: str) -> None:
     logger = structlog.get_logger(__name__)
-    engine = create_database_engine(TEST_DATABASE_URL, TEST_DATABASE_PASSWORD)
+    engine = create_database_engine(database_url, TEST_DATABASE_PASSWORD)
     await initialize_database(engine, logger, schema=Base.metadata, reset=True)
     session = await create_async_session(engine, logger)
     await db_session_dependency.initialize(
-        TEST_DATABASE_URL, TEST_DATABASE_PASSWORD
+        database_url, TEST_DATABASE_PASSWORD
     )
 
     app = FastAPI()

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,10 @@ isolated_build = True
 
 [docker:postgres]
 image = postgres:latest
-ports =
-    5432:5432/tcp
 environment =
     POSTGRES_PASSWORD=INSECURE@%PASSWORD/
     POSTGRES_USER=safir
     POSTGRES_DB=safir
-    PGPORT=5432
 # The healthcheck ensures that tox-docker won't run tests until the
 # container is up and the command finishes with exit code 0 (success)
 healthcheck_cmd = PGPASSWORD=$POSTGRES_PASSWORD psql \
@@ -24,8 +21,6 @@ healthcheck_start_period = 1
 
 [docker:redis]
 image = redis:latest
-ports =
-    6379:6379/tcp
 healthcheck_cmd =
     redis-cli ping
 healthcheck_timeout = 1
@@ -51,7 +46,6 @@ docker =
 commands =
     coverage run -m pytest {posargs}
 setenv =
-    TEST_DATABASE_URL = postgresql://safir@127.0.0.1/safir
     TEST_DATABASE_PASSWORD = INSECURE@%PASSWORD/
 
 [testenv:coverage-report]


### PR DESCRIPTION
Support the latest tox-docker version and unpin requests, since the incompatibility is now fixed. The latest tox-docker no longer starts Docker images on localhost or with reliable ports, so modify the test setup to use the new tox-docker-exposed environment variables to locate the test PostgreSQL and Redis services.