### PR TITLE
DM-44444: Remove version cap on structlog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pydantic>2,<3",
     "starlette<1",
     # 23.3.0 excluded due to https://github.com/hynek/structlog/issues/584
-    "structlog>=21.2.0,!=23.3.0,<25",
+    "structlog>=21.2.0,!=23.3.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
structlog [uses CalVer](https://github.com/hynek/structlog/blob/main/.github/SECURITY.md) and changes the major version for each year. The structlog developers recommend letting the version float, since the major version has no semantic significance. Backwards compatibility is handled through deprecation warnings.