### PR TITLE
DM-44606: Allow SecretStr in DatabaseSessionDependency

### DIFF
--- a/changelog.d/20240520_163147_rra_DM_44444.md
+++ b/changelog.d/20240520_163147_rra_DM_44444.md
@@ -1,3 +1,3 @@
 ### New features
 
-- Allow the database password to be passed to `create_database_engine` and `create_sync_session` as a Pydantic `SecretStr`.
+- Allow the database password to be passed to `create_database_engine`, `create_sync_session`, and `DatabaseSessionDependency.initialize` as a Pydantic `SecretStr`.

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncIterator
 
+from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
 
 from ..database import create_async_session, create_database_engine
@@ -68,7 +69,7 @@ class DatabaseSessionDependency:
     async def initialize(
         self,
         url: str,
-        password: str | None,
+        password: str | SecretStr | None,
         *,
         isolation_level: str | None = None,
     ) -> None:


### PR DESCRIPTION
Following the change to create_database_engine, also allow the password argument to DatabaseSessionDependency.initialize to be a SecretStr.