### PR TITLE
DM-44606: Drop DatabaseSessionDependency.override_engine

### DIFF
--- a/changelog.d/20240530_173040_rra_DM_44606.md
+++ b/changelog.d/20240530_173040_rra_DM_44606.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Drop `DatabaseSessionDependency.override_engine`. This was used for Gafaelfawr to share a database engine across all tests for speed, but this technique breaks with current versions of pytest-asyncio and is no longer used or safe to use.


### PR DESCRIPTION
This was used for Gafaelfawr to share a database engine across all tests for speed, but this technique breaks with current versions of pytest-asyncio and is no longer used or safe to use.