### PR TITLE
DM-44606: Fix default_queue_name in RedisArqQueue

### DIFF
--- a/changelog.d/20240605_173149_rra_DM_44606_queue.md
+++ b/changelog.d/20240605_173149_rra_DM_44606_queue.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Correctly honor the `default_queue_name` argument to `RedisArqQueue.initialize`.

--- a/src/safir/arq.py
+++ b/src/safir/arq.py
@@ -404,7 +404,7 @@ class RedisArqQueue(ArqQueue):
         pool = await create_pool(
             redis_settings, default_queue_name=default_queue_name
         )
-        return cls(pool)
+        return cls(pool, default_queue_name=default_queue_name)
 
     async def enqueue(
         self,


### PR DESCRIPTION
The initialize method of RedisArqQueue didn't pass the `default_queue_name` argument to `__init__`, so the default queue name was forced to the default. It was set correctly in the pool, but the `enqueue` method overrides the queue name from the pool, so that setting had no effect. This caused messages without an explicit `_queue_name` argument to always be sent to the default queue regardless of the arguments to initialize.