### PR TITLE
DM-44720: Support pickling of `SlackException`

### DIFF
--- a/changelog.d/20240607_112935_rra_DM_44720.md
+++ b/changelog.d/20240607_112935_rra_DM_44720.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support pickling of `SlackException` so that subclasses of it can be thrown by arq workers and unpickled correctly when retrieving results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ select = ["ALL"]
     "PT012",   # way too aggressive about limiting pytest.raises blocks
     "S101",    # tests should use assert
     "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # one test verifies that a class can be pickled
     "SLF001",  # tests are allowed to access private members
 ]
 

--- a/tests/testing/gcs_test.py
+++ b/tests/testing/gcs_test.py
@@ -24,7 +24,7 @@ def test_mock(mock_gcs: MockStorageClient) -> None:
     credentials = google.auth.default()
     signing_credentials = impersonated_credentials.Credentials(
         source_credentials=credentials,
-        target_principle="some-service-account",
+        target_principal="some-service-account",
         target_scopes="https://www.googleapis.com/auth/devstorage.read_only",
         lifetime=2,
     )
@@ -62,7 +62,7 @@ def test_mock_files(mock_gcs_file: MockStorageClient) -> None:
     credentials = google.auth.default()
     signing_credentials = impersonated_credentials.Credentials(
         source_credentials=credentials,
-        target_principle="some-service-account",
+        target_principal="some-service-account",
         target_scopes="https://www.googleapis.com/auth/devstorage.read_only",
         lifetime=2,
     )


### PR DESCRIPTION
Exception classes that call the `BaseException.__init__` method (possibly via `Exception`) with a different number of arguments than the `__init__` method of the derived exception class takes cannot be pickled and unpickled. Since arq uses pickle to record the exception of failed jobs, and we may want such exceptions to be derived from `SlackException` so that we can easily report them to Slack, this is an annoying limitation. The restriction is due to the properties of the default `__reduce__` method on `BaseException` and probably cannot be changed in Python.

Work around this by using the pattern recommended at the end of the discussion in https://github.com/python/cpython/issues/44791, namely avoid calling `BaseException.__init__` entirely. This means we can no longer rely on the default `__str__` behavior and must implement `__str__`.

Add a test that `SlackException` and classes derived from it with different numbers of constructor arguments can be pickled and unpickled without loss of the information that goes into `to_slack`.