### PR TITLE
DM-45137: Update dependencies, switch to uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,15 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.2
+    rev: v0.5.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.2.0]
+        additional_dependencies: [black==24.4.2]
         args: [-l, '76', -t, py311]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ help:
 	@echo "make clean - Remove generated files"
 	@echo "make init - Set up dev environment (install pre-commit hooks)"
 	@echo "make linkcheck - Check for broken links in documentation"
+	@echo "make update - Update pre-commit dependencies and run make init"
+	@echo "make update-deps - Update pre-commit dependencies"
 
 .PHONY: clean
 clean:
@@ -13,8 +15,9 @@ clean:
 
 .PHONY: init
 init:
-	pip install --upgrade pip tox tox-docker pre-commit
-	pip install --upgrade -e ".[arq,db,dev,gcs,kubernetes]"
+	pip install --upgrade uv
+	uv pip install --upgrade pre-commit tox tox-docker tox-uv
+	uv pip install --upgrade -e ".[arq,db,dev,gcs,kubernetes]"
 	pre-commit install
 	rm -rf .tox
 
@@ -27,3 +30,16 @@ linkcheck:
 	sphinx-build --keep-going -n -T -b linkcheck docs	\
 	    docs/_build/linkcheck				\
 	    || (cat docs/_build/linkcheck/output.txt; exit 1)
+
+# update and update-deps aren't that meaningful for PyPI packages that do
+# not have pinned Python package dependencies, but provide the same targets
+# as the FastAPI Safir app template so that people can use the same command
+# to update everything at the start of development (here, just pre-commit).
+.PHONY: update
+update: update-deps init
+
+.PHONY: update-deps
+update-deps:
+	pip install --upgrade uv
+	uv pip install --upgrade pre-commit
+	pre-commit autoupdate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,9 @@ ignore = [
     "COM819",
     "ISC001",
     "ISC002",
+
+    # Temporary bug workarounds.
+    "S113",    # https://github.com/astral-sh/ruff/issues/12210
 ]
 select = ["ALL"]
 


### PR DESCRIPTION
Update pre-commit dependencies.

Switch to uv for dependency installation in the Makefile, and add update and update-deps targets for parallelism with FastAPI application packages, even though update-deps doesn't do much (just update uv and pre-commit and run pre-commit autoupdate).