### PR TITLE
DM-45138: Allow custom serializers for Redis arq queue

### DIFF
--- a/changelog.d/20240709_171415_rra_DM_45138.md
+++ b/changelog.d/20240709_171415_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support custom job serializers and deserializers in `safir.arg.RedisArqQueue`.

--- a/src/safir/arq.py
+++ b/src/safir/arq.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -399,10 +400,15 @@ class RedisArqQueue(ArqQueue):
         redis_settings: RedisSettings,
         *,
         default_queue_name: str = arq_default_queue_name,
+        job_serializer: Callable[[Any], bytes] | None = None,
+        job_deserializer: Callable[[bytes], Any] | None = None,
     ) -> Self:
         """Initialize a RedisArqQueue from Redis settings."""
         pool = await create_pool(
-            redis_settings, default_queue_name=default_queue_name
+            redis_settings,
+            default_queue_name=default_queue_name,
+            job_serializer=job_serializer,
+            job_deserializer=job_deserializer,
         )
         return cls(pool, default_queue_name=default_queue_name)
 


### PR DESCRIPTION
For UWS applications, to reduce pickle problems between different versions of libraries and Python, we plan to use a custom serializer that uses Pydantic's JSON serialization. arq supports custom serializers, but they weren't supported by RedisArqQueue. Plumb those arguments through the initialize class method.