### PR TITLE
DM-45138: Add support for aborting arq jobs

### DIFF
--- a/changelog.d/20240711_120038_rra_DM_45138.md
+++ b/changelog.d/20240711_120038_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `abort_job` method to instances of `safir.arq.ArqQueue`, which tells arq to abort a job that has been queued or in progress. To successfully abort a job that has already started, the arq worker must enable support for aborting jobs.


### PR DESCRIPTION
Add a new `abort_job` method to instances of `safir.arq.ArqQueue`, which tries to abort a job. If the job has already started, this requires the worker to enable support for aborting jobs.

The mock implementation deletes the job entirely if it hasn't been started, and treats it as if it failed with asyncio.CancelledError if it were already running. This seems to match what arq does with a Redis queue.