### PR TITLE
Add `pull_requests` to `GitHubCheckSuiteModel`

### DIFF
--- a/changelog.d/20240712_100038_danfuchs_mobu_github_app.md
+++ b/changelog.d/20240712_100038_danfuchs_mobu_github_app.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Add `pull_requests` to `GitHubCheckSuiteModel` to capture info about any pull requests associated with a GitHub check suite event.

--- a/src/safir/github/models.py
+++ b/src/safir/github/models.py
@@ -296,6 +296,10 @@ class GitHubCheckSuiteModel(BaseModel):
         description="The conclusion of the check suite."
     )
 
+    pull_requests: list[GitHubCheckRunPrInfoModel] = Field(
+        description="A list of pull requests associated with this check suite."
+    )
+
 
 class GitHubCheckRunStatus(str, Enum):
     """The check run status."""


### PR DESCRIPTION
Needed by mobu to [decide whether or not to create a check suite](https://github.com/lsst-sqre/mobu/blob/6390b7bedbffa61317d570f92cd42500acd8a9c0/src/mobu/handlers/github_ci_app.py#L93).

Confirmed `pull_requests` is an empty array when the check suite event is not associated with an PR:

```json
{
  "action": "requested",
  "check_suite": {
    "id": 25911226694,
    "node_id": "CS_kwDOL_KXns8AAAAGCG3xRg",
    "head_branch": "main",
    "head_sha": "a956612459352be98b651eef40c315a01039b672",
    "status": "queued",
    "conclusion": null,
    "url": "https://api.github.com/repos/lsst-sqre/dfuchs-test-mobu/check-suites/25911226694",
    "before": "2504ccedcb5663f87dce23225755e3b26dfc6d40",
    "after": "a956612459352be98b651eef40c315a01039b672",
    "pull_requests": [

    ],
```