### PR TITLE
DM-45281: Add Pydantic types for Postgres and Redis DSNs

### DIFF
--- a/changelog.d/20240717_101902_rra_DM_45281_queue.md
+++ b/changelog.d/20240717_101902_rra_DM_45281_queue.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new types `safir.pydantic.EnvAsyncPostgresDsn` and `safir.pydantic.EnvRedisDsn`, which validate PostgreSQL and Redis DSNs but rewrite them based on the environment variables set by tox-docker. Programs using these types for their configuration will therefore automatically honor tox-docker environment variables when running the test suite. `EnvAsyncPostgresDsn` also enforces that the scheme of the DSN is compatible with asyncpg and the Safir database support.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -23,4 +23,5 @@
 .. _structlog: https://www.structlog.org/en/stable/
 .. _templatekit: https://templatekit.lsst.io
 .. _tox: https://tox.wiki/en/latest/
+.. _tox-docker: https://tox-docker.readthedocs.io/en/latest/
 .. _Uvicorn: https://www.uvicorn.org/

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -25,6 +25,8 @@ nitpick_ignore = [
     ["py:class", "BaseModel"],
     # sphinx-automodapi apparently doesn't recognize TypeAlias as an object
     # that should have generated documentation, even with include-all-objects.
+    ["py:obj", "safir.pydantic.EnvAsyncPostgresDsn"],
+    ["py:obj", "safir.pydantic.EnvRedisDsn"],
     ["py:obj", "safir.pydantic.HumanTimedelta"],
     ["py:obj", "safir.pydantic.SecondsTimedelta"],
 ]

--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -50,13 +50,14 @@ If your app uses a configuration system like ``pydantic.BaseSettings``, this exa
     from urllib.parse import urlparse
 
     from arq.connections import RedisSettings
-    from pydantic import Field, RedisDsn
+    from pydantic import Field
     from pydantic_settings import BaseSettings
     from safir.arq import ArqMode
+    from safir.pydantic import EnvRedisDsn
 
 
     class Config(BaseSettings):
-        arq_queue_url: RedisDsn = Field(
+        arq_queue_url: EnvRedisDsn = Field(
             "redis://localhost:6379/1", validation_alias="APP_ARQ_QUEUE_URL"
         )
 
@@ -76,6 +77,9 @@ If your app uses a configuration system like ``pydantic.BaseSettings``, this exa
                 ),
             )
             return redis_settings
+
+The `safir.pydantic.EnvRedisDsn` type will automatically incorporate Redis location information from tox-docker.
+See :ref:`pydantic-dsns` for more details.
 
 Worker set up
 -------------

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -13,6 +13,8 @@ Safir uses the `asyncpg`_ PostgreSQL database driver.
 Database support in Safir is optional.
 To use it, depend on ``safir[db]`` in your pip requirements.
 
+Also see :ref:`pydantic-dsns` for Pydantic types that help with configuring the PostgreSQL DSN.
+
 Initializing a database
 =======================
 


### PR DESCRIPTION
Add new types `safir.pydantic.EnvAsyncPostgresDsn` and `safir.pydantic.EnvRedisDsn`, which validate PostgreSQL and Redis DSNs but rewrite them based on the environment variables set by tox-docker. Programs using these types for their configuration will therefore automatically honor tox-docker environment variables when running the test suite. `EnvAsyncPostgresDsn` also enforces that the scheme of the DSN is compatible with asyncpg and the Safir database support.