### PR TITLE
DM-45281: Add decorator to retry async transactions

### DIFF
--- a/changelog.d/20240717_212929_rra_DM_45281_queue.md
+++ b/changelog.d/20240717_212929_rra_DM_45281_queue.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add the decorator `safir.database.retry_async_transaction`, which retries a function or method a configurable number of times if it raises a SQLAlchemy exception from the underlying database API. This is primarily intended to retry database operations aborted due to transaction isolation.

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -468,3 +468,15 @@ Here's a simplified example from the storage layer of a Safir application:
                job.start_time = start
 
 If this method races with other methods updating the same job, the custom isolation level will force this update to fail with an exception, and it will then be retried by the decorator.
+
+By default, the method is attempted three times.
+This can be changed with a parameter to the decorator, such as:
+
+.. code-block:: python
+   :emphasize-lines: 2
+
+   class Storage:
+       @retry_async_transaction(max_tries=5)
+       async def mark_start(self, job_id: str, start: datetime) -> None:
+           async with self._session.begin():
+               ...

--- a/docs/user-guide/database.rst
+++ b/docs/user-guide/database.rst
@@ -469,14 +469,14 @@ Here's a simplified example from the storage layer of a Safir application:
 
 If this method races with other methods updating the same job, the custom isolation level will force this update to fail with an exception, and it will then be retried by the decorator.
 
-By default, the method is attempted three times.
-This can be changed with a parameter to the decorator, such as:
+The decorator will delay for half a second (configurable with the ``delay`` parameter) between attempts, and by default the method is attempted three times.
+These can be changed with a parameter to the decorator, such as:
 
 .. code-block:: python
    :emphasize-lines: 2
 
    class Storage:
-       @retry_async_transaction(max_tries=5)
+       @retry_async_transaction(max_tries=5, delay=2.5)
        async def mark_start(self, job_id: str, start: datetime) -> None:
            async with self._session.begin():
                ...

--- a/src/safir/database/__init__.py
+++ b/src/safir/database/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ._connection import create_async_session, create_database_engine
 from ._datetime import datetime_from_db, datetime_to_db
 from ._initialize import DatabaseInitializationError, initialize_database
+from ._retry import RetryP, RetryT, retry_async_transaction
 
 __all__ = [
     "DatabaseInitializationError",
@@ -13,4 +14,8 @@ __all__ = [
     "datetime_from_db",
     "datetime_to_db",
     "initialize_database",
+    "retry_async_transaction",
+    # Included only for documentation purposes.
+    "RetryP",
+    "RetryT",
 ]

--- a/src/safir/database/_retry.py
+++ b/src/safir/database/_retry.py
@@ -1,0 +1,103 @@
+"""Database transaction retry support."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable, Coroutine
+from functools import wraps
+from typing import ParamSpec, TypeAlias, TypeVar, overload
+
+from sqlalchemy.exc import DBAPIError
+
+#: Return type of a database call being retried.
+RetryT = TypeVar("RetryT")
+
+#: Parameters of a database call being retried.
+RetryP = ParamSpec("RetryP")
+
+#: Database call that can be retried.
+RetryF: TypeAlias = Callable[RetryP, Coroutine[None, None, RetryT]]
+
+__all__ = [
+    "RetryF",
+    "RetryP",
+    "RetryT",
+    "retry_async_transaction",
+]
+
+
+@overload
+def retry_async_transaction(__func: RetryF) -> RetryF: ...
+
+
+@overload
+def retry_async_transaction(
+    *, max_retries: int = 2
+) -> Callable[[RetryF], RetryF]: ...
+
+
+def retry_async_transaction(
+    __func: RetryF | None = None, *, max_retries: int = 2
+) -> RetryF | Callable[[RetryF], RetryF]:
+    """Retry if a transaction failed.
+
+    If the wrapped method fails with an `sqlalchemy.exc.DBAPIError` exception,
+    it is retried up to ``max_retries`` times. Any method with this decorator
+    must be idempotent, since it may be re-run multiple times.
+
+    One common use for this decorator is when the database engine has been
+    configured with the ``REPEATABLE READ`` transaction isolation level and
+    multiple writers may be updating the same object at the same time. The
+    loser of the transaction race will raise one of the above exceptions, and
+    can be retried with this decorator.
+
+    Parameters
+    ----------
+    max_retries
+        Number of times to retry the transaction. Practical experience with
+        ``REPEATABLE READ`` isolation suggests a count of at least two.
+
+    Examples
+    --------
+    This decorator can be used with any idempotent Python function or method
+    that makes database calls and should be retried on the above-listed
+    exceptions.
+
+    .. code-block:: python
+
+       from safir.database import retry_async_transaction
+       from sqlalchemy.ext.asyncio import async_scoped_session
+
+
+       @retry_async_transaction(max_retries=5)
+       def make_some_database_call(session: async_scoped_session) -> None: ...
+
+    If the default value of ``max_retries`` is acceptable, this decorator can
+    be used without arguments.
+
+    .. code-block:: python
+
+       from safir.database import retry_async_transaction
+       from sqlalchemy.ext.asyncio import async_scoped_session
+
+
+       @retry_async_transaction
+       def make_some_database_call(session: async_scoped_session) -> None: ...
+    """
+
+    def decorator(f: RetryF) -> RetryF:
+        @wraps(f)
+        async def wrapper(
+            *args: RetryP.args, **kwargs: RetryP.kwargs
+        ) -> RetryT:
+            for _ in range(1, max_retries):
+                with contextlib.suppress(DBAPIError):
+                    return await f(*args, **kwargs)
+            return await f(*args, **kwargs)
+
+        return wrapper
+
+    if __func is not None:
+        return decorator(__func)
+    else:
+        return decorator

--- a/src/safir/database/_retry.py
+++ b/src/safir/database/_retry.py
@@ -32,17 +32,17 @@ def retry_async_transaction(__func: RetryF) -> RetryF: ...
 
 @overload
 def retry_async_transaction(
-    *, max_retries: int = 2
+    *, max_tries: int = 3
 ) -> Callable[[RetryF], RetryF]: ...
 
 
 def retry_async_transaction(
-    __func: RetryF | None = None, *, max_retries: int = 2
+    __func: RetryF | None = None, *, max_tries: int = 3
 ) -> RetryF | Callable[[RetryF], RetryF]:
     """Retry if a transaction failed.
 
     If the wrapped method fails with an `sqlalchemy.exc.DBAPIError` exception,
-    it is retried up to ``max_retries`` times. Any method with this decorator
+    it is retried up to ``max_tries`` times. Any method with this decorator
     must be idempotent, since it may be re-run multiple times.
 
     One common use for this decorator is when the database engine has been
@@ -53,9 +53,9 @@ def retry_async_transaction(
 
     Parameters
     ----------
-    max_retries
+    max_tries
         Number of times to retry the transaction. Practical experience with
-        ``REPEATABLE READ`` isolation suggests a count of at least two.
+        ``REPEATABLE READ`` isolation suggests a count of at least three.
 
     Examples
     --------
@@ -69,10 +69,10 @@ def retry_async_transaction(
        from sqlalchemy.ext.asyncio import async_scoped_session
 
 
-       @retry_async_transaction(max_retries=5)
+       @retry_async_transaction(max_tries=5)
        def make_some_database_call(session: async_scoped_session) -> None: ...
 
-    If the default value of ``max_retries`` is acceptable, this decorator can
+    If the default value of ``max_tries`` is acceptable, this decorator can
     be used without arguments.
 
     .. code-block:: python
@@ -90,7 +90,7 @@ def retry_async_transaction(
         async def wrapper(
             *args: RetryP.args, **kwargs: RetryP.kwargs
         ) -> RetryT:
-            for _ in range(1, max_retries):
+            for _ in range(1, max_tries):
                 with contextlib.suppress(DBAPIError):
                     return await f(*args, **kwargs)
             return await f(*args, **kwargs)

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -176,13 +176,13 @@ async def test_retry_async_transaction(database_url: str) -> None:
                 raise OperationalError(None, None, ValueError("foo"))
             session.add(User(username="newuser"))
 
-    await insert(1)
+    await insert(2)
 
     tries = 0
     with pytest.raises(OperationalError):
-        await insert(2)
+        await insert(3)
 
-    @retry_async_transaction(max_retries=1)
+    @retry_async_transaction(max_tries=1)
     async def insert_capped(attempts: int) -> None:
         nonlocal tries
         tries += 1


### PR DESCRIPTION
Add `safir.database.retry_async_transaction`, which retries a function or method a configurable number of times if it fails with a SQLAlchemy exception indicating a problem with the underlying database layer, such as that raised when there is a conflicting transaction.