### PR TITLE
DM-45779: Allow a `Url` for database session initialization

### DIFF
--- a/changelog.d/20240814_155547_rra_DM_45779.md
+++ b/changelog.d/20240814_155547_rra_DM_45779.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow the database URL passed to `DatabaseSessionDependency.initialize` to be a Pydantic `Url`. This simplifies logic for applications that use `EnvAsyncPostgresDsn` or other Pydantic URL types for their configuration.

--- a/safir/src/safir/dependencies/db_session.py
+++ b/safir/src/safir/dependencies/db_session.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncIterator
 
 from pydantic import SecretStr
+from pydantic_core import Url
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
 
 from safir.database import create_async_session, create_database_engine
@@ -67,7 +68,7 @@ class DatabaseSessionDependency:
 
     async def initialize(
         self,
-        url: str,
+        url: str | Url,
         password: str | SecretStr | None,
         *,
         isolation_level: str | None = None,


### PR DESCRIPTION
Allow the database URL argument to `DatabaseSessionDependency`'s initialize method to be a Pydantic `Url`. This allows applications that use `EnvAsyncPostgresDsn` or similar Pydantic types for the database URL in their configuration to not do an explicit conversion.