### PR TITLE
DM-45779: Allow `mock_slack_webhook` to take `SecretStr`

### DIFF
--- a/changelog.d/20240814_170047_rra_DM_45779a.md
+++ b/changelog.d/20240814_170047_rra_DM_45779a.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow the hook URL argument to `safir.testing.slack.mock_slack_webhook` to be a Pydantic `SecretStr`.

--- a/safir/src/safir/testing/slack.py
+++ b/safir/src/safir/testing/slack.py
@@ -7,12 +7,18 @@ from typing import Any
 
 import respx
 from httpx import Request, Response
+from pydantic import SecretStr
 
 __all__ = ["MockSlackWebhook", "mock_slack_webhook"]
 
 
 class MockSlackWebhook:
     """Represents a Slack incoming webhook and remembers what was posted.
+
+    Parameters
+    ----------
+    url
+        URL that the mock has been configured to listen on.
 
     Attributes
     ----------
@@ -46,7 +52,7 @@ class MockSlackWebhook:
 
 
 def mock_slack_webhook(
-    hook_url: str, respx_mock: respx.Router
+    hook_url: str | SecretStr, respx_mock: respx.Router
 ) -> MockSlackWebhook:
     """Set up a mocked Slack server.
 
@@ -92,6 +98,8 @@ def mock_slack_webhook(
            # Do something with client that generates Slack messages.
            assert mock_slack.messages == [{...}, {...}]
     """
+    if isinstance(hook_url, SecretStr):
+        hook_url = hook_url.get_secret_value()
     mock = MockSlackWebhook(hook_url)
     respx_mock.post(hook_url).mock(side_effect=mock.post_webhook)
     return mock


### PR DESCRIPTION
Parallel to the constructor of the actual `SlackWebhookClient`, allow `mock_slack_webhook` to take a Pydantic `SecretStr`. This makes integration with test configurations easier.