### PR TITLE
DM-45818: Fix UWS Availability during errors

### DIFF
--- a/changelog.d/20240816_105321_rra_DM_45818.md
+++ b/changelog.d/20240816_105321_rra_DM_45818.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix construction of an `Availability` object reporting problems with the UWS database layer to use the correct field names and data type for the model.

--- a/safir/src/safir/uws/_storage.py
+++ b/safir/src/safir/uws/_storage.py
@@ -163,10 +163,10 @@ class JobStore:
             return Availability(available=True)
         except OperationalError:
             note = "cannot query UWS job database"
-            return Availability(available=False, note=note)
+            return Availability(available=False, notes=[note])
         except Exception as e:
             note = f"{type(e).__name__}: {e!s}"
-            return Availability(available=False, note=note)
+            return Availability(available=False, notes=[note])
 
     async def delete(self, job_id: str) -> None:
         """Delete a job by ID."""


### PR DESCRIPTION
The syntax for creating a UWS Availability model was incorrect: the field is notes, not note, and it takes an array of strings.