### PR TITLE
DM-45824: Cap dependency on safir-logging

### DIFF
--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "httpx>=0.20.0,<1",
     "pydantic>2,<3",
     "pydantic-core",
-    "safir-logging",
+    "safir-logging<7",
     "starlette<1",
     "structlog>=21.2.0",
 ]


### PR DESCRIPTION
Cap the major version of the safir dependency on safir-logging, following what we did with safir-arq and ensuring that we do not install an incompatible version.