### PR TITLE
DM-46034: Remove now-unnecessary `type: ignore` markers

### DIFF
--- a/safir/tests/dependencies/arq_test.py
+++ b/safir/tests/dependencies/arq_test.py
@@ -138,7 +138,7 @@ async def test_arq_dependency_mock() -> None:
         except JobNotFound as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with LifespanManager(app):
         async with AsyncClient(transport=transport, base_url=base_url) as c:

--- a/safir/tests/dependencies/db_session_test.py
+++ b/safir/tests/dependencies/db_session_test.py
@@ -60,7 +60,7 @@ async def test_session(database_url: str, database_password: str) -> None:
             result = await session.scalars(select(User.username))
             return list(result.all())
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/list")

--- a/safir/tests/dependencies/gafaelfawr_test.py
+++ b/safir/tests/dependencies/gafaelfawr_test.py
@@ -29,7 +29,7 @@ async def test_auth_dependency() -> None:
     ) -> dict[str, str]:
         return {"user": user}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/")
@@ -50,7 +50,7 @@ async def test_auth_delegated_token_dependency() -> None:
     ) -> dict[str, str]:
         return {"token": token}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/")
@@ -79,7 +79,7 @@ async def test_auth_logger_dependency(
         return {}
 
     caplog.clear()
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/", headers={"User-Agent": ""})

--- a/safir/tests/dependencies/http_client_test.py
+++ b/safir/tests/dependencies/http_client_test.py
@@ -39,7 +39,7 @@ async def test_http_client(respx_mock: respx.Router) -> None:
         await http_client.get("https://www.google.com")
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with LifespanManager(app):
         async with AsyncClient(transport=transport, base_url=base_url) as c:

--- a/safir/tests/dependencies/logger_test.py
+++ b/safir/tests/dependencies/logger_test.py
@@ -30,7 +30,7 @@ async def test_logger(caplog: pytest.LogCaptureFixture) -> None:
         return {}
 
     caplog.clear()
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(
@@ -69,7 +69,7 @@ async def test_logger_xforwarded(caplog: pytest.LogCaptureFixture) -> None:
         return {}
 
     caplog.clear()
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(

--- a/safir/tests/fastapi_test.py
+++ b/safir/tests/fastapi_test.py
@@ -43,7 +43,7 @@ async def test_client_request_error() -> None:
     async def permission_error() -> dict[str, str]:
         raise PermissionDeniedError("Permission denied")
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/user")

--- a/safir/tests/middleware/ivoa_test.py
+++ b/safir/tests/middleware/ivoa_test.py
@@ -36,7 +36,7 @@ async def test_case_insensitive() -> None:
     ) -> dict[str, list[str]]:
         return {"param": param}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "https://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/", params={"param": "foo"})

--- a/safir/tests/middleware/x_forwarded_test.py
+++ b/safir/tests/middleware/x_forwarded_test.py
@@ -31,7 +31,7 @@ async def test_ok() -> None:
         assert request.url == "https://foo.example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(
@@ -58,7 +58,7 @@ async def test_defaults() -> None:
         assert request.url == "http://example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(
@@ -84,7 +84,7 @@ async def test_no_forwards() -> None:
         assert request.url == "http://example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get("/")
@@ -103,7 +103,7 @@ async def test_all_filtered() -> None:
         assert request.url == "https://example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(
@@ -129,7 +129,7 @@ async def test_one_proto() -> None:
         assert request.url == "https://example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(
@@ -155,7 +155,7 @@ async def test_no_proto_or_host() -> None:
         assert request.url == "http://example.com/"
         return {}
 
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     base_url = "http://example.com"
     async with AsyncClient(transport=transport, base_url=base_url) as client:
         r = await client.get(

--- a/safir/tests/slack/webhook_test.py
+++ b/safir/tests/slack/webhook_test.py
@@ -153,10 +153,7 @@ async def test_route_handler(mock_slack: MockSlackWebhook) -> None:
 
     # We need a custom HTTPX configuration to disable raising server
     # exceptions so that we can inspect the resulting error handling.
-    transport = ASGITransport(
-        app=app,  # type: ignore[arg-type]
-        raise_app_exceptions=False,
-    )
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
 
     # Run the test.
     base_url = "https://example.com"

--- a/safir/tests/uws/conftest.py
+++ b/safir/tests/uws/conftest.py
@@ -70,7 +70,7 @@ def arq_queue() -> MockArqQueue:
 @pytest_asyncio.fixture
 async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport,
         base_url="https://example.com/",

--- a/safir/tests/uws/job_api_test.py
+++ b/safir/tests/uws/job_api_test.py
@@ -535,8 +535,7 @@ async def test_redirects(
     # Try various actions that result in redirects and ensure the redirect is
     # correct.
     async with AsyncClient(
-        transport=ASGITransport(app=app),  # type: ignore[arg-type]
-        base_url="http://foo.com/",
+        transport=ASGITransport(app=app), base_url="http://foo.com/"
     ) as client:
         r = await client.post(
             "/test/jobs/1/destruction",


### PR DESCRIPTION
The latest version of httpx and mypy no longer needs `type: ignore` markers when creating the transport for testing applications.