### PR TITLE
DM-46034: Add new pytest-asyncio configuration

### DIFF
--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -129,6 +129,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
     # The point of this test is to test handling of datetime-naive UTC


### PR DESCRIPTION
pytest-asyncio is changing the default loop lifetime for fixtures and now warns about not explicitly setting a default. Set the default for Safir to the new value.