### PR TITLE
DM-46034: Remove remaining declarative_base references

### DIFF
--- a/docs/user-guide/database/initialize.rst
+++ b/docs/user-guide/database/initialize.rst
@@ -19,14 +19,16 @@ In the file :file:`schema/base.py`, define the SQLAlchemy declarative base:
 
 .. code-block:: python
 
-   from sqlalchemy.orm import declarative_base
+   from sqlalchemy.orm import DeclarativeBase
 
-   Base = declarative_base()
 
-In other files in that directory, define the database tables using the normal SQLAlchemy ORM syntax, one table per file.
+   class Base(DeclarativeBase):
+       """Declarative base for SQLAlchemy ORM model of database schema."""
+
+In other files in that directory, define the database tables using the `normal SQLAlchemy ORM syntax <https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#declarative-mapping>`__, one table per file.
 Each database table definition must inherit from ``Base``, imported from ``.base``.
 
-In :file:`schema/__init__.py`, import the table definitions from all of the files in the directory, as well as the ``Base`` variable, and export them using ``__all__``.
+In :file:`schema/__init__.py`, import the table definitions from all of the files in the directory, as well as the ``Base`` class, and export them using ``__all__``.
 
 Using non-default PostgreSQL schemas
 ------------------------------------

--- a/safir/tests/dependencies/db_session_test.py
+++ b/safir/tests/dependencies/db_session_test.py
@@ -8,10 +8,10 @@ import pytest
 import structlog
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, String
+from sqlalchemy import String
 from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from safir.database import (
     create_async_session,
@@ -20,7 +20,9 @@ from safir.database import (
 )
 from safir.dependencies.db_session import db_session_dependency
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    """Declarative base for testing."""
 
 
 class User(Base):
@@ -28,7 +30,7 @@ class User(Base):
 
     __tablename__ = "user"
 
-    username: str = Column(String(64), primary_key=True)
+    username: Mapped[str] = mapped_column(String(64), primary_key=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Update the documentation for defining a database schema and one test case to use the new `DeclarativeBase` inheritance syntax. Add a documentation link to the current way of defining ORM models with SQLAlchemy.