### PR TITLE
DM-44365: `vo-models` integration fixes

### DIFF
--- a/changelog.d/20241009_155401_danfuchs_vo_models_type_compatibility.md
+++ b/changelog.d/20241009_155401_danfuchs_vo_models_type_compatibility.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- [vo-models](https://github.com/spacetelescope/vo-models) integration fixes

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -87,7 +87,7 @@ uws = [
     "python-multipart",
     "safir-arq<7",
     "sqlalchemy[asyncio]>=1.4.18,<3",
-    "vo-models<1",
+    "vo-models>=0.4.1,<1",
 ]
 
 [[project.authors]]

--- a/safir/src/safir/uws/_models.py
+++ b/safir/src/safir/uws/_models.py
@@ -17,6 +17,7 @@ from vo_models.uws import (
     Parameter,
     Parameters,
     ResultReference,
+    Results,
     ShortJobDescription,
 )
 from vo_models.uws.types import ErrorType, ExecutionPhase, UWSVersion
@@ -307,7 +308,7 @@ class UWSJob:
         """Convert to a Pydantic XML model."""
         results = None
         if self.results:
-            results = [r.to_xml_model() for r in self.results]
+            results = Results(results=[r.to_xml_model() for r in self.results])
         return JobSummary(
             job_id=self.job_id,
             run_id=self.run_id,

--- a/safir/src/safir/uws/_storage.py
+++ b/safir/src/safir/uws/_storage.py
@@ -163,10 +163,10 @@ class JobStore:
             return Availability(available=True)
         except OperationalError:
             note = "cannot query UWS job database"
-            return Availability(available=False, notes=[note])
+            return Availability(available=False, note=[note])
         except Exception as e:
             note = f"{type(e).__name__}: {e!s}"
-            return Availability(available=False, notes=[note])
+            return Availability(available=False, note=[note])
 
     async def delete(self, job_id: str) -> None:
         """Delete a job by ID."""


### PR DESCRIPTION
Now that [there's a py.typed in vo-models](https://github.com/spacetelescope/vo-models/commit/956c049c1c1782efbe0e5e37fb9f0a479704e53b), `mypy` is showing some incorrect usage.

Note that a version of `vo-models` with [these changes](https://github.com/spacetelescope/vo-models/compare/main...fajpunk:vo-models:export-names?expand=1) is needed to get a clean typecheck.