### PR TITLE
DM-45522: Use `timedelta`s in event payloads

### DIFF
--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -110,6 +110,13 @@ We can do this all in an ``events.py`` file.
    Fields in metrics events can't be other models or other nested types like dicts, because the current event datastore (InfluxDB) does not support this.
    Basing our event payloads on `safir.metrics.EventPayload` will enable the `~safir.metrics.EventManager` to ensure at runtime when our events are registered that they don't contain incompatible fields.
 
+.. warning::
+
+   `dataclasses-avroschema`_ does not currently support timedelta fields, and will throw an exception if you define a field of type ``timedelta`` in your event payload model.
+   To work around this, you can declare any ``timedelta`` fields as type `~safir.metrics.EventDuration`.
+   You can pass a ``timedelta`` object as a value, and the field will serialize to the float number of seconds represented by the duration.
+   You can only use this type in models that are subclasses of `~safir.metrics.EventPayload`.
+
 .. code-block:: python
    :caption: metrics.py
 
@@ -118,6 +125,7 @@ We can do this all in an ``events.py`` file.
 
    from pydantic import Field
    from safir.metrics import (
+       EventDuration,
        EventManager,
        EventPayload,
    )
@@ -136,7 +144,7 @@ We can do this all in an ``events.py`` file.
            title="Query type", description="The kind of query"
        )
 
-       duration: timedelta = Field(
+       duration: EventDuration = Field(
            title="Query duration", description="How long the query took to run"
        )
 
@@ -148,6 +156,8 @@ We can do this all in an ``events.py`` file.
 
    # We'll call .initalize on this in our app start up
    events_dependency = EventDependency(Events())
+
+.. _dataclasses-avroschema: https://marcosschroh.github.io/dataclasses-avroschema
 
 Initialize
 ----------

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -5,10 +5,11 @@ from ._exceptions import (
     EventManagerUnintializedError,
     KafkaTopicError,
 )
-from ._models import EventMetadata, EventPayload
+from ._models import EventDuration, EventMetadata, EventPayload
 
 __all__ = [
     "DuplicateEventError",
+    "EventDuration",
     "EventManager",
     "EventManagerUnintializedError",
     "EventMetadata",

--- a/safir/src/safir/metrics/_models.py
+++ b/safir/src/safir/metrics/_models.py
@@ -1,9 +1,86 @@
 """Models for representing metrics events."""
 
-from dataclasses_avroschema.pydantic import AvroBaseModel
-from pydantic import UUID4, AwareDatetime, Field, create_model
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
-__all__ = ["EventMetadata", "EventPayload"]
+from dataclasses_avroschema.pydantic import AvroBaseModel
+from pydantic import (
+    UUID4,
+    AwareDatetime,
+    ConfigDict,
+    Field,
+    GetCoreSchemaHandler,
+    create_model,
+)
+from pydantic_core import CoreSchema, core_schema
+
+__all__ = ["EventDuration", "EventMetadata", "EventPayload"]
+
+
+if TYPE_CHECKING:
+    EventDuration = timedelta
+else:
+
+    class EventDuration(timedelta):
+        """A dataclasses-avroschema-compatible timedelta field that serializes
+        to float seconds.
+
+        .. note::
+
+           Models that use fields of this type must be subclasses of
+           `~safir.metrics.EventPayload`.
+
+        dataclasses-avroschema has no built-in support for timedelta fields
+        (even though Pydantic does), and if you declare one in your event
+        payload model, an exception will be thrown when you try to serialize
+        it. By declaring your field with this type, you'll be able to use
+        timedeltas, and they will serialze to a float number of seconds.
+
+        Examples
+        --------
+        .. code-block:: python
+
+           from datetime import datetime, timedelta, timezone
+           from safir.metrics import EventDuration, EventPayload
+
+
+           class MyEvent(EventPayload):
+               some_field: str = Field()
+               duration: EventDuration = Field()
+
+
+           start_time = datetime.now(timezone.utc)
+           do_some_stuff()
+           duration: timedelta = datetime.now(timezone.utc) - start_time
+
+           payload = MyEvent(some_field="woohoo", duration=duration)
+        """
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source_type: Any, handler: GetCoreSchemaHandler
+        ) -> CoreSchema:
+            """Pretend we're a timedelta.
+
+            We need this because dataclasses-avroschema explicitly looks for
+            this method when trying to serialize a custom Pydantic type.
+            """
+
+            def validate(v: Any) -> EventDuration:
+                if isinstance(v, timedelta):
+                    return EventDuration(seconds=v.total_seconds())
+                elif isinstance(v, EventDuration):
+                    return v
+                else:
+                    raise TypeError("Must be a timedelta or EventDuration")
+
+            return core_schema.no_info_after_validator_function(
+                validate, core_schema.timedelta_schema()
+            )
+
+        def __float__(self) -> float:
+            """Convert to a float number of seconds."""
+            return self.total_seconds()
 
 
 class EventMetadata(AvroBaseModel):
@@ -41,6 +118,14 @@ class EventMetadata(AvroBaseModel):
 
 class EventPayload(AvroBaseModel):
     """All event payloads should inherit from this."""
+
+    # json_encoders is deprecated in Pydantic v2, but dataclasses-avroschema
+    # insists that it is defined for custom types, and that the value for a
+    # custom type is one of the built-in dataclasses-avroschema base types
+    # (which is why __float__ needs to be defined on the EventDuration class):
+    #
+    # https://github.com/marcosschroh/dataclasses-avroschema/blob/b8f7b8dfa877fea58887e4cd34d34e2ab6551afa/dataclasses_avroschema/fields/fields.py#L1000-L1038
+    model_config = ConfigDict(json_encoders={EventDuration: float})
 
     @classmethod
     def validate_structure(cls) -> None:


### PR DESCRIPTION
This is admittedly somewhat nasty, and depends on a deprecated Pydantic feature (`json_encoders` in model config), but I think it's the only way to be able to serialize time deltas directly on `AvroBaseModel` models.

[This](https://github.com/marcosschroh/dataclasses-avroschema/blob/b8f7b8dfa877fea58887e4cd34d34e2ab6551afa/dataclasses_avroschema/fields/fields.py#L1000-L1038) is the code that enables this is [dataclasses-avroschema](https://github.com/marcosschroh/dataclasses-avroschema).  It requires explicitly that:
* The custom type has a `__get_pydantic_core_schema__` method
* The model has a (deprecated) `json_encoders` config set
* This `json_encoders` dict maps the custom type to a function that is itself one of the types that is [natively supported by dataclasses-avroschema](https://marcosschroh.github.io/dataclasses-avroschema/fields_specification/#avro-field-and-python-types-summary), which is why the custom type needs a `__float__` method.

This is sorta the way that Pydantic custom type serialization works, but has other requirements that are specific to `dataclasses-avroschema`, which is why it looks pretty weird (to me).

Because this is weird and depends on a deprecated Pydantic feature (that logs a warning when it's used), it may be worth trying to contribute native timedelta support to `dataclasses-avroschema`.
