### PR TITLE
DM-46821: Move warning suppression to an annotation

### DIFF
--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -23,18 +23,18 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "aiokafka>=0.11",
+    "aiokafka>=0.11,<1",
     "click<9",
     "cryptography<44",
-    "dataclasses-avroschema>0.62",
+    "dataclasses-avroschema>0.62,<1",
     "fastapi<1",
     "faststream>0.5,<0.6",
     "gidgethub<6",
     "httpx>=0.20.0,<1",
     "pydantic>2,<3",
     "pydantic-core",
-    "pydantic-settings!=2.6.0",
-    "python-schema-registry-client>=2.6",
+    "pydantic-settings!=2.6.0,<3",
+    "python-schema-registry-client>=2.6,<3",
     "safir-logging<7",
     "starlette<1",
     "structlog>=21.2.0",
@@ -86,7 +86,7 @@ uws = [
     "jinja2<4",
     "python-multipart",
     "safir-arq<7",
-    "sqlalchemy[asyncio]>=1.4.18,<3",
+    "sqlalchemy[asyncio]>=2.0.0,<3",
     "vo-models>=0.4.1,<1",
 ]
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -137,10 +137,6 @@ exclude_lines = [
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
-    # The point of this test is to test handling of datetime-naive UTC
-    # objects, which is what the deprecation warning is about. We want to
-    # continue doing this until the support has been removed entirely.
-    "ignore:datetime.datetime.utcnow:DeprecationWarning:tests.pydantic_test",
     # Temporary until we can get timedelta support into dataclasses-avroschema.
     "ignore:.*json_encoders.*is deprecated.*",
 ]

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "fastapi>=0.93.0",
     "mypy",
     "pre-commit",
-    "pytest",
+    "pytest>=6.2.0",
     "pytest-asyncio",
     "pytest-cov",
     "redis>=5,<6",

--- a/safir/tests/pydantic_test.py
+++ b/safir/tests/pydantic_test.py
@@ -175,6 +175,7 @@ def test_seconds_timedelta() -> None:
         TestModel.model_validate({"delta": "P1DT12H"})
 
 
+@pytest.mark.filterwarnings("ignore:.*datetime.utcnow.*:DeprecationWarning")
 def test_normalize_datetime() -> None:
     class TestModel(BaseModel):
         time: datetime | None


### PR DESCRIPTION
One specific test of Safir uses `datetime.utcnow`, which is deprecated. Move the warning suppression out of `pyproject.toml` to an annotation on that function, since we'll be keeping that test until the upstream function is removed entirely.