### PR TITLE
DM-47011: Allow extra values to disabled metrics config

### DIFF
--- a/changelog.d/20241021_091054_rra_DM_47011.md
+++ b/changelog.d/20241021_091054_rra_DM_47011.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Allow and ignore extra attributes to `MetricsConfiguration` when metrics are disabled. This allows passing a partial metrics configuration even when they are disabled, which simplifies the structure of Phalanx configurations based on dumping the Helm values into a YAML configuraiton file.

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -87,12 +87,6 @@ class BaseMetricsConfiguration(BaseSettings, ABC):
         title="Events configuration",
     )
 
-    model_config = SettingsConfigDict(
-        alias_generator=to_camel,
-        extra="forbid",
-        populate_by_name=True,
-    )
-
     @abstractmethod
     def make_manager(self, logger: BoundLogger | None = None) -> EventManager:
         """Construct an EventManager.
@@ -124,6 +118,8 @@ class DisabledMetricsConfiguration(BaseMetricsConfiguration):
         ),
         validation_alias=AliasChoices("enabled", "METRICS_ENABLED"),
     )
+
+    model_config = SettingsConfigDict(extra="ignore", populate_by_name=True)
 
     def make_manager(
         self, logger: BoundLogger | None = None
@@ -158,6 +154,12 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
     schema_manager: SchemaManagerSettings = Field(
         default_factory=SchemaManagerSettings,
         title="Kafka schema manager settings",
+    )
+
+    model_config = SettingsConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
     )
 
     def make_manager(

--- a/safir/tests/metrics/config_test.py
+++ b/safir/tests/metrics/config_test.py
@@ -32,6 +32,23 @@ def test_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(manager, NoopEventManager)
 
 
+def test_disabled_extra() -> None:
+    config = Config.model_validate(
+        {
+            "metrics": {
+                "enabled": False,
+                "application": "example",
+                "events": {"topicPrefix": "lsst.square.metrics.events"},
+                "schemaManager": {
+                    "registryUrl": "https://example.com",
+                    "suffix": "",
+                },
+            }
+        }
+    )
+    assert isinstance(config.metrics, DisabledMetricsConfiguration)
+
+
 @pytest.mark.asyncio
 async def test_kafka(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("METRICS_APPLICATION", "test")


### PR DESCRIPTION
Allow and ignore extra attributes to `MetricsConfiguration` when metrics are disabled. This allows passing a partial metrics configuration even when they are disabled, which simplifies the structure of Phalanx configurations based on dumping the Helm values into a YAML configuraiton file.