### PR TITLE
DM-47027: Change ws_post_params_dependency to handle multiple occurrences of the same param

### DIFF
--- a/changelog.d/20241022_002510_steliosvoutsinas_DM_47027.md
+++ b/changelog.d/20241022_002510_steliosvoutsinas_DM_47027.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Change uws_post_params_dependency to support reading in multiple of the same param

--- a/safir/src/safir/uws/_dependencies.py
+++ b/safir/src/safir/uws/_dependencies.py
@@ -187,7 +187,7 @@ async def uws_post_params_dependency(
     if request.method != "POST":
         raise ValueError("uws_post_params_dependency used for non-POST route")
     parameters = []
-    for key, value in (await request.form()).items():
+    for key, value in (await request.form()).multi_items():
         if not isinstance(value, str):
             raise TypeError("File upload not supported")
         parameters.append(

--- a/safir/tests/uws/post_params_test.py
+++ b/safir/tests/uws/post_params_test.py
@@ -1,0 +1,30 @@
+"""Tests for sync cutout requests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_post_params_multiple_params(client: AsyncClient) -> None:
+    """Test that the post dependency correctly handles multiple
+    occurences of the same parameter.
+    """
+    params = [
+        {"parameter_id": "id", "value": "image1"},
+        {"parameter_id": "id", "value": "image2"},
+        {"parameter_id": "pos", "value": "RANGE 10 20 30 40"},
+        {"parameter_id": "pos", "value": "CIRCLE 10 20 5"},
+    ]
+
+    response = await client.post("/test/params", json=params)
+    assert response.status_code == 200
+    assert response.json() == {
+        "params": [
+            {"id": "id", "value": "image1"},
+            {"id": "id", "value": "image2"},
+            {"id": "pos", "value": "RANGE 10 20 30 40"},
+            {"id": "pos", "value": "CIRCLE 10 20 5"},
+        ]
+    }


### PR DESCRIPTION
**Summary**

PR addresses issue where the uws_post_params dependency did not correctly read in list parameters, i.e. multiple occurrences of the same param. The fix was to change items() to multi_items() on the request.form() object.
A test has been added which sets up a test endpoint which returns the params passed in to the request, and exercises it with a request with multiple of the same param.