### PR TITLE
Fix `PydanticRedisStorage` documentation

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -63,17 +63,17 @@ extensions = [
 ]
 
 [sphinx.intersphinx.projects]
-aiokafka = "https://aiokafka.readthedocs.io/en/stable/"
+aiokafka = "https://aiokafka.readthedocs.io/en/stable"
 arq = "https://arq-docs.helpmanual.io"
-click = "https://click.palletsprojects.com/"
-cryptography = "https://cryptography.io/en/latest/"
-gidgethub = "https://gidgethub.readthedocs.io/en/latest/"
-python = "https://docs.python.org/3/"
-redis = "https://redis-py.readthedocs.io/en/stable/"
-schema_registry = "https://marcosschroh.github.io/python-schema-registry-client/"
-structlog = "https://www.structlog.org/en/stable/"
-sqlalchemy = "https://docs.sqlalchemy.org/en/latest/"
-vomodels = "https://vo-models.readthedocs.io/latest/"
+click = "https://click.palletsprojects.com"
+cryptography = "https://cryptography.io/en/latest"
+gidgethub = "https://gidgethub.readthedocs.io/en/latest"
+python = "https://docs.python.org/3"
+redis = "https://redis-py.readthedocs.io/en/stable"
+schema_registry = "https://marcosschroh.github.io/python-schema-registry-client"
+structlog = "https://www.structlog.org/en/stable"
+sqlalchemy = "https://docs.sqlalchemy.org/en/latest"
+vomodels = "https://vo-models.readthedocs.io/latest"
 
 [sphinx.linkcheck]
 ignore = [

--- a/docs/user-guide/pydantic-redis.rst
+++ b/docs/user-guide/pydantic-redis.rst
@@ -33,7 +33,7 @@ Here is a basic set up:
 
 
    redis_client = redis.Redis("redis://localhost:6379/0")
-   mymodel_storage = PydanticRedisStorage(MyModel, redis_client)
+   mymodel_storage = PydanticRedisStorage(datatype=MyModel, redis=redis_client)
 
 Use the `~safir.redis.PydanticRedisStorage.store` method to store a Pydantic object in Redis with a specific key:
 


### PR DESCRIPTION
The first example of using `PydanticRedisStorage` does not use keyword arguments, but keyword arguments are required. Fix the documentation to match the code. Reported by @Fireye04.