### PR TITLE
DM-45522 metrics: native `timedelta` support

### DIFF
--- a/changelog.d/20241106_103655_danfuchs_metrics_timedelta_builtin.md
+++ b/changelog.d/20241106_103655_danfuchs_metrics_timedelta_builtin.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- `EventDuration` has been removed from `safir.metrics`. You can now use Python's built-in `timedelta` as the type for any field you were previously using `EventDuration`. It will be serialized the same way, as an Avro `double` number of seconds.

--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -111,12 +111,10 @@ We can do this all in an :file:`events.py` file.
    Fields in metrics events can't be other models or other nested types like dicts, because the current event datastore (InfluxDB) does not support this.
    Basing our event payloads on `safir.metrics.EventPayload` will enable the `~safir.metrics.EventManager` to ensure at runtime when our events are registered that they don't contain incompatible fields.
 
-.. warning::
+.. note::
 
-   `dataclasses-avroschema`_ does not currently support timedelta fields, and will throw an exception if you define a field of type ``timedelta`` in your event payload model.
-   To work around this, you can declare any ``timedelta`` fields as type `~safir.metrics.EventDuration`.
-   You can pass a ``timedelta`` object as a value, and the field will serialize to the float number of seconds represented by the duration.
-   You can only use this type in models that are subclasses of `~safir.metrics.EventPayload`.
+   Any ``timedelta`` fields will be serialized as an Avro ``double`` number of seconds.
+
 
 .. code-block:: python
    :caption: metrics.py
@@ -126,7 +124,6 @@ We can do this all in an :file:`events.py` file.
 
    from pydantic import Field
    from safir.metrics import (
-       EventDuration,
        EventManager,
        EventPayload,
    )
@@ -145,7 +142,7 @@ We can do this all in an :file:`events.py` file.
            title="Query type", description="The kind of query"
        )
 
-       duration: EventDuration = Field(
+       duration: timedelta = Field(
            title="Query duration", description="How long the query took to run"
        )
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "aiokafka>=0.11,<1",
     "click<9",
     "cryptography<44",
-    "dataclasses-avroschema>0.62,<1",
+    "dataclasses-avroschema>=0.65,<1",
     "fastapi<1",
     "faststream>0.5,<0.6",
     "gidgethub<6",
@@ -136,10 +136,6 @@ exclude_lines = [
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
-filterwarnings = [
-    # Temporary until we can get timedelta support into dataclasses-avroschema.
-    "ignore:.*json_encoders.*is deprecated.*",
-]
 python_files = [
     "tests/*.py",
     "tests/*/*.py"

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -19,13 +19,12 @@ from ._exceptions import (
     EventManagerUnintializedError,
     KafkaTopicError,
 )
-from ._models import EventDuration, EventMetadata, EventPayload
+from ._models import EventMetadata, EventPayload
 
 __all__ = [
     "BaseMetricsConfiguration",
     "DisabledMetricsConfiguration",
     "DuplicateEventError",
-    "EventDuration",
     "EventsConfiguration",
     "EventManager",
     "EventManagerUnintializedError",

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -29,7 +29,6 @@ from safir.kafka import (
 from safir.metrics import (
     DisabledMetricsConfiguration,
     DuplicateEventError,
-    EventDuration,
     EventManager,
     EventManagerUnintializedError,
     EventMetadata,
@@ -47,7 +46,7 @@ class MyEvent(EventPayload):
     """An event payload."""
 
     foo: str
-    duration: EventDuration
+    duration: timedelta
 
 
 class Events(EventMaker):


### PR DESCRIPTION
Require a version of `dataclasses-avroschema` with native `timedetla` support, and remove the `EventDuration` custom pydantic type.