### PR TITLE
DM-47262: Fix IVOA DALI timestamp parsing, add data types

### DIFF
--- a/changelog.d/20241113_152723_rra_DM_47262a.md
+++ b/changelog.d/20241113_152723_rra_DM_47262a.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- `parse_isodatetime` and `normalize_isodatetime` now accept exactly the date formats accepted by the IVOA DALI standard. This means seconds are now required, the trailing `Z` is now optional (times are always interpreted as UTC regardless), and the time is optional and interpreted as 00:00:00 if missing.
+
+### New features
+
+- Add new `safir.pydantic.UtcDatetime` type that is equivalent to `datetime` but coerces all incoming times to timezone-aware UTC. This type should be used instead of using `normalize_datetime` as a validator.
+- Add new `safir.pydantic.IvoaIsoDatetime` type that accepts any ISO 8601 date and time that matches the IVOA DALI standard for timestamps. This follows the same rules as `parse_isodatetime` now follows. This type should be used instead of using `normalize_isodatetime` as a validator.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -40,7 +40,9 @@ nitpick_ignore = [
     ["py:obj", "safir.pydantic.EnvAsyncPostgresDsn"],
     ["py:obj", "safir.pydantic.EnvRedisDsn"],
     ["py:obj", "safir.pydantic.HumanTimedelta"],
+    ["py:obj", "safir.pydantic.IvoaIsoDatetime"],
     ["py:obj", "safir.pydantic.SecondsTimedelta"],
+    ["py:obj", "safir.pydantic.UtcDatetime"],
     # TypeVar references used as parameters to Generic seem to create target
     # not found errors even if they are exported when they are used in private
     # submodules.

--- a/docs/user-guide/datetime.rst
+++ b/docs/user-guide/datetime.rst
@@ -41,28 +41,13 @@ ISO 8601 is a large and complex standard that supports numerous partial date or 
 However, its most basic date and time format, ``YYYY-MM-DDTHH:MM:SSZ`` (where the ``T`` and ``Z`` are fixed letters and the other letters represent their normal date and time components), provides a good balance of unambiguous parsing and human readability.
 The trailing ``Z`` indicates UTC.
 
-This subset of ISO 8601 is used by both Kubernetes and the IVOA UWS standard.
+This subset of ISO 8601 is used by both Kubernetes and the IVOA DALI standard, but the IVOA DALI standard allows omitting ``Z`` (the time is still interpreted as UTC) and omitting the time portion entirely.
 
-Safir provides two utility functions for this date and time serialization format.
+Safir provides two utility functions for this subset of ISO 8601.
 `safir.datetime.isodatetime` converts a `~datetime.datetime` to this format.
 `safir.datetime.parse_isodatetime` goes the opposite direction, converting this format to a time zone aware `~datetime.datetime` in UTC.
 
-To use this format as the serialized representation of any `~datetime.datetime` objects in a Pydantic model, use the following Pydantic configuration:
-
-.. code-block:: python
-
-   from datetime import datetime
-
-   from pydantic import BaseModel, field_serializer
-   from safir.datetime import isodatetime
-
-
-   class Example(BaseModel):
-       some_time: datetime
-
-       _serialize_some_time = field_serializer("some_time")(isodatetime)
-
-Also see the Pydantic validation function `safir.pydantic.normalize_isodatetime`, discussed further at :ref:`pydantic-datetime`.
+If, as is more often the case, you are accepting or generating `~datetime.datetime` fields as part of a Pydantic model, see :ref:`pydantic-datetime`.
 
 Formatting datetimes for logging
 ================================

--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -62,40 +62,43 @@ Normalizing datetime fields
 Pydantic supports several input formats for `~datetime.datetime` fields, but the resulting `~datetime.datetime` object may be timezone-naive.
 Best practice for Python code is to only use timezone-aware `~datetime.datetime` objects in the UTC time zone.
 
-Safir provides a utility function, `~safir.pydantic.normalize_datetime`, that can be used as a field validator for a `~datetime.datetime` model field.
-It ensures that any input is converted to UTC and is always timezone-aware.
+Safir provides a data type, `~safir.pydantic.UtcDatetime`, that can be used in models.
+It is equivalent to `~datetime.datetime` except that it coerces any input to UTC and ensures that it is always timezone-aware.
 
 Here's an example of how to use it:
 
 .. code-block:: python
 
+   from typing import Annotated
+
    from pydantic import BaseModel, field_validator
-   from safir.pydantic import normalize_datetime
+   from safir.pydantic import UtcDatetime
 
 
    class Info(BaseModel):
-       last_used: Optional[datetime] = Field(
-           None,
-           title="Last used",
-           description="When last used in seconds since epoch",
-           examples=[1614986130],
-       )
+       last_used: Annotated[
+           UtcDatetime | None,
+           Field(
+               title="Last used",
+               description="When last used",
+               examples=[1614986130, "2021-03-05T15:15:30+00:00"],
+           ),
+       ]
 
-       _normalize_last_used = field_validator("last_used", mode="before")(
-           normalize_datetime
-       )
+This data type accepts all of the input formats that Pydantic accepts.
 
-Multiple attributes can be listed as the initial arguments of `~pydantic.field_validator` if there are multiple fields that need to be checked.
+IVOA DALI timestamps
+--------------------
 
-This field validator accepts all of the input formats that Pydantic accepts.
-This includes some ambiguous formats, such as an ISO 8601 date without time zone information.
-All such dates are given a consistent interpretation as UTC, but the results may be surprising if the caller expected local time.
-In some cases, it may be desirable to restrict input to one unambiguous format.
+In some cases, such as services that implement IVOA standards, it may be desirable to require input timestamps compatible with the `IVOA DALI`_ standard.
 
-This can be done by using `~safir.pydantic.normalize_isodatetime` as the field validator instead.
-This function only accepts ``YYYY-MM-DDTHH:MM[:SS]Z`` as the input format.
-The ``Z`` time zone prefix indicating UTC is mandatory.
-It is called the same way as `~safir.pydantic.normalize_datetime`.
+.. _IVOA DALI: https://www.ivoa.net/documents/DALI/20170517/REC-DALI-1.1.html
+
+This can be done using `~safir.pydantic.IvoaIsoDatetime` as the data type instead of `~safir.pydantic.UtcDatetime`.
+This data type produces the same timezone-aware UTC `~datetime.datetime` objects, but it only accepts ``YYYY-MM-DD[THH:MM:SS[.mmm]][Z]`` as the input format.
+
+Following the IVOA DALI standard, the trailing ``Z`` is optional, but the timestamp is always interpreted as UTC.
+Explicit timezone information is not allowed.
 
 .. _pydantic-timedelta:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ extend = "ruff-shared.toml"
 "*/src/safir/**" = [
     "N818",    # Exception is correct in some cases, others are part of API
 ]
+"safir/src/safir/pydantic/_validators.py" = [
+    "TRY004",  # pydantic requires ValueError, not TypeError
+]
 "safir/src/safir/testing/**" = [
     "S101",    # test support functions are allowed to use assert
 ]

--- a/safir/src/safir/pydantic/__init__.py
+++ b/safir/src/safir/pydantic/__init__.py
@@ -5,7 +5,9 @@ from ._types import (
     EnvAsyncPostgresDsn,
     EnvRedisDsn,
     HumanTimedelta,
+    IvoaIsoDatetime,
     SecondsTimedelta,
+    UtcDatetime,
 )
 from ._validators import (
     normalize_datetime,
@@ -18,7 +20,9 @@ __all__ = [
     "EnvAsyncPostgresDsn",
     "EnvRedisDsn",
     "HumanTimedelta",
+    "IvoaIsoDatetime",
     "SecondsTimedelta",
+    "UtcDatetime",
     "normalize_datetime",
     "normalize_isodatetime",
     "to_camel_case",

--- a/safir/tests/datetime_test.py
+++ b/safir/tests/datetime_test.py
@@ -54,8 +54,12 @@ def test_parse_isodatetime() -> None:
     assert time == datetime(2022, 9, 16, 12, 3, 45, tzinfo=UTC)
     now = current_datetime()
     assert parse_isodatetime(isodatetime(now)) == now
+    time = parse_isodatetime("2022-09-16T12:03:45")
+    assert time == datetime(2022, 9, 16, 12, 3, 45, tzinfo=UTC)
+    time = parse_isodatetime("2022-09-16")
+    assert time == datetime(2022, 9, 16, 0, 0, 0, tzinfo=UTC)
 
-    with pytest.raises(ValueError, match=r".* does not end with Z"):
+    with pytest.raises(ValueError, match="does not match IVOA format"):
         parse_isodatetime("2022-09-16T12:03:45+00:00")
 
 

--- a/safir/tests/uws/errors_test.py
+++ b/safir/tests/uws/errors_test.py
@@ -117,10 +117,11 @@ async def test_errors(
         PostTest("/test/jobs/1/destruction", {"destruction": "next tuesday"}),
         PostTest("/test/jobs/1/destruction", {"DESTruction": "next tuesday"}),
         PostTest(
-            "/test/jobs/1/destruction", {"destruction": "2021-09-10T10:01:02"}
+            "/test/jobs/1/destruction", {"destruction": "2021-09-10 10:01:02"}
         ),
         PostTest(
-            "/test/jobs/1/destruction", {"destrucTION": "2021-09-10T10:01:02"}
+            "/test/jobs/1/destruction",
+            {"destrucTION": "2021-09-10T10:01:02+00:00:00"},
         ),
         PostTest("/test/jobs/1/executionduration", {"executionduration": "0"}),
         PostTest("/test/jobs/1/executionduration", {"executionDUration": "0"}),
@@ -141,8 +142,8 @@ async def test_errors(
         r = await client.post(
             test.url, data=test.data, headers={"X-Auth-Request-User": "user"}
         )
-        assert r.status_code == 422
-        assert r.text.startswith("UsageError")
+        assert r.status_code == 422, f"{test.url} {test.data}"
+        assert r.text.startswith("UsageError"), r.text
 
     # Test bogus phase for async job creation.
     r = await client.post(


### PR DESCRIPTION
Change `parse_isodatetime` and `normalize_isodatetime` to support exactly the formats specified by the IVOA DALI standard (and fix incorrect references to UWS). This means supporting timestamps without the time component and making the trailing Z optional, but requiring seconds be present if the time portion is present. This should not interfere with the other uses, such as parsing Kubernetes timestamps.

Add new data types `UtcDatetime` and `IvoaIsoDatetime` that are now the preferred way to use the normalization functions in models. The former accepts any format Pydantic supports but coerces it to UTC and timezone-aware. The latter accepts only the formats supported by `parse_isodatetime`. Document those data types instead of the normalization functions, although the normalization functions are still available (for now).