### PR TITLE
DM-47262: Document testing Alembic config against schema

### DIFF
--- a/changelog.d/20241113_165421_rra_DM_47262b.md
+++ b/changelog.d/20241113_165421_rra_DM_47262b.md
@@ -1,0 +1,7 @@
+### New features
+
+- Add `safir.database.drop_database` utility function to drop all database tables mentioned in a SQLAlchemy ORM schema and delete the Alembic version information if it is present. This is primarily useful for tests.
+
+### Other changes
+
+- Document how to test an application's database schema against its Alembic migrations to ensure that the schema hasn't been modified without adding a corresponding migration.

--- a/docs/user-guide/database/testing.rst
+++ b/docs/user-guide/database/testing.rst
@@ -7,6 +7,8 @@ While support for SQLite could be added, testing against the database that will 
 
 The recommended strategy for testing applications that use a database is to start a real PostgreSQL server for the tests.
 
+Also see :ref:`database-alembic-testing` for information on how to test Alembic schema management.
+
 Using tox-docker
 ================
 

--- a/safir/src/safir/database/__init__.py
+++ b/safir/src/safir/database/__init__.py
@@ -11,7 +11,11 @@ from ._alembic import (
 )
 from ._connection import create_async_session, create_database_engine
 from ._datetime import datetime_from_db, datetime_to_db
-from ._initialize import DatabaseInitializationError, initialize_database
+from ._initialize import (
+    DatabaseInitializationError,
+    drop_database,
+    initialize_database,
+)
 from ._retry import RetryP, RetryT, retry_async_transaction
 
 __all__ = [
@@ -21,6 +25,7 @@ __all__ = [
     "create_database_engine",
     "datetime_from_db",
     "datetime_to_db",
+    "drop_database",
     "initialize_database",
     "is_database_current",
     "retry_async_transaction",

--- a/safir/src/safir/database/_initialize.py
+++ b/safir/src/safir/database/_initialize.py
@@ -10,14 +10,32 @@ from sqlalchemy.schema import CreateSchema
 from sqlalchemy.sql.schema import MetaData
 from structlog.stdlib import BoundLogger
 
+from ._alembic import unstamp_database
+
 __all__ = [
     "DatabaseInitializationError",
+    "drop_database",
     "initialize_database",
 ]
 
 
 class DatabaseInitializationError(Exception):
     """Database initialization failed."""
+
+
+async def drop_database(engine: AsyncEngine, schema: MetaData) -> None:
+    """Drop all tables from the database.
+
+    Parameters
+    ----------
+    engine
+        Engine to use to issue the SQL commands.
+    schema
+        Database ORM schema.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(schema.drop_all)
+    await unstamp_database(engine)
 
 
 async def initialize_database(


### PR DESCRIPTION
Document how to test the current SQLAlchemy ORM schema against the Alembic migrations to catch schema changes that have no corresponding migration. Document creating an initial Alembic migration that creates the initial schema. Add the `safir.database.drop_database` utility function to make it easier to write that test case.