### PR TITLE
DM-47262: Add Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
         python:
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -26,6 +26,7 @@ jobs:
         python:
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/20241114_105840_rra_DM_47262.md
+++ b/changelog.d/20241114_105840_rra_DM_47262.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Mark Python 3.13 as supported and add it to the test matrix.

--- a/safir-arq/pyproject.toml
+++ b/safir-arq/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",

--- a/safir-logging/pyproject.toml
+++ b/safir-logging/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",


### PR DESCRIPTION
Add Python 3.13 to the supported versions for each package, and add it to the test matrix.