### PR TITLE
`timedelta` can now be used a member of a union field in an EventPayload

### DIFF
--- a/changelog.d/20241119_132629_danfuchs_fix_metrics_timedelta.md
+++ b/changelog.d/20241119_132629_danfuchs_fix_metrics_timedelta.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- `timedelta` can now be a member of a union field in a `safir.metrics.EventPayload`

--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -148,7 +148,7 @@ We can do this all in an :file:`events.py` file.
 
 
    class Events(EventMaker):
-       async def initialize(manager: EventManager) -> None:
+       async def initialize(self, manager: EventManager) -> None:
            self.query = await manager.create_publisher("query", QueryEvent)
 
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "aiokafka>=0.11,<1",
     "click<9",
     "cryptography<44",
-    "dataclasses-avroschema>=0.65,<1",
+    "dataclasses-avroschema>=0.65.3,<1",
     "fastapi<1",
     "faststream>0.5,<0.6",
     "gidgethub<6",

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -47,6 +47,7 @@ class MyEvent(EventPayload):
 
     foo: str
     duration: timedelta
+    duration_union: timedelta | None
 
 
 class Events(EventMaker):
@@ -133,12 +134,14 @@ async def integration_test(
         MyEvent(
             foo="bar1",
             duration=timedelta(seconds=2, milliseconds=123),
+            duration_union=None,
         )
     )
     published = await event.publish(
         MyEvent(
             foo="bar2",
             duration=timedelta(seconds=2, milliseconds=456),
+            duration_union=None,
         )
     )
     schema = published.avro_schema_to_python()
@@ -325,6 +328,10 @@ async def test_disable() -> None:
     await manager.initialize()
     event = await manager.create_publisher("myevent", MyEvent)
 
-    await event.publish(MyEvent(foo="bar1", duration=timedelta(seconds=1)))
-    await event.publish(MyEvent(foo="bar2", duration=timedelta(seconds=1)))
+    await event.publish(
+        MyEvent(foo="bar1", duration=timedelta(seconds=1), duration_union=None)
+    )
+    await event.publish(
+        MyEvent(foo="bar2", duration=timedelta(seconds=1), duration_union=None)
+    )
     await manager.aclose()


### PR DESCRIPTION
This is two bug fixes:
* One in this lib where validation of `EventPayload` models was broken for unions
* One in [dataclasses-avroschema](https://github.com/marcosschroh/dataclasses-avroschema/pull/797) where timedeltas could not be serialized in Avro unions