### PR TITLE
DM-47771: metrics: don't wait for kafka messages to be delivered

### DIFF
--- a/changelog.d/20241122_164744_danfuchs_metrics_publishing_is_slow.md
+++ b/changelog.d/20241122_164744_danfuchs_metrics_publishing_is_slow.md
@@ -1,0 +1,3 @@
+### New features
+
+- Publishing a metrics event no longer waits on confirmation of message delivery to Kafka. This makes publishing much more performant. All events will still be delivered as long as an app awaits `EventManager.aclose` in its lifecycle.

--- a/safir/src/safir/metrics/_event_manager.py
+++ b/safir/src/safir/metrics/_event_manager.py
@@ -483,7 +483,7 @@ class KafkaEventManager(EventManager):
             msg = "Initialize EventManager before creating event publishers"
             raise EventManagerUnintializedError(msg)
         encoded = await self._schema_manager.serialize(event)
-        await publisher.publish(encoded)
+        await publisher.publish(encoded, no_confirm=True)
         self.logger.debug(
             "Published metrics event",
             metrics_event=event.model_dump(),


### PR DESCRIPTION
`aoikafka` publishes messages via a background task and provides futures to wait for actual delivery. `faststream` waits on these futures by default. We don't need to wait for publishing app metrics.

Initial performance tracing of Gafaelfawr showed 5-20ms taken up when publishing an event, with this patch, it seems to take ~0.3ms.

Thanks to @rra for finding this performance issue!