### PR TITLE
DM-47769: Remove obsolete SQLAlchemy future flags

### DIFF
--- a/docs/user-guide/database/session.rst
+++ b/docs/user-guide/database/session.rst
@@ -46,7 +46,7 @@ For example:
 .. code-block:: python
 
    import structlog
-   from sqlalchemy.future import select
+   from sqlalchemy import select
 
    from .schema import User
 

--- a/safir/src/safir/database/_connection.py
+++ b/safir/src/safir/database/_connection.py
@@ -105,11 +105,9 @@ def create_database_engine(
     """
     url = build_database_url(url, password)
     if isolation_level:
-        return create_async_engine(
-            url, future=True, isolation_level=isolation_level
-        )
+        return create_async_engine(url, isolation_level=isolation_level)
     else:
-        return create_async_engine(url, future=True)
+        return create_async_engine(url)
 
 
 async def create_async_session(


### PR DESCRIPTION
Importing from `sqlalchemy.future` and passing `future=True` when creating sessions is no longer required since we require SQLAlchemy 2.0 or later.