### PR TITLE
DM-47796: Add alembic dependency to uws extra

### DIFF
--- a/changelog.d/20241125_140320_rra_DM_47796.md
+++ b/changelog.d/20241125_140320_rra_DM_47796.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add missing dependency on alembic to the `safir[uws]` extra.

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -80,6 +80,7 @@ redis = [
     "redis>4.5.2,<6",
 ]
 uws = [
+    "alembic[tz]<2",
     "asyncpg<1",
     "google-auth<3",
     "google-cloud-storage<3",


### PR DESCRIPTION
Add alembic as a dependency to the `safir[uws]` extra. That extra currently must duplicate all of the dependencies of `safir[db]`, since it loads the Safir database support. This can be dropped once the UWS code in Safir is a front-end for Wobbly.