### PR TITLE
DM-47789: Fix various issues with pagination support

### DIFF
--- a/safir/src/safir/database/__init__.py
+++ b/safir/src/safir/database/__init__.py
@@ -18,10 +18,11 @@ from ._initialize import (
 )
 from ._pagination import (
     DatetimeIdCursor,
-    PaginatedLinkData,
+    InvalidCursorError,
     PaginatedList,
     PaginatedQueryRunner,
     PaginationCursor,
+    PaginationLinkData,
 )
 from ._retry import retry_async_transaction
 
@@ -29,10 +30,11 @@ __all__ = [
     "AlembicConfigError",
     "DatabaseInitializationError",
     "DatetimeIdCursor",
-    "PaginatedLinkData",
+    "InvalidCursorError",
     "PaginatedList",
     "PaginatedQueryRunner",
     "PaginationCursor",
+    "PaginationLinkData",
     "create_async_session",
     "create_database_engine",
     "datetime_from_db",

--- a/safir/tests/database_test.py
+++ b/safir/tests/database_test.py
@@ -27,8 +27,8 @@ from starlette.datastructures import URL
 
 from safir.database import (
     DatetimeIdCursor,
-    PaginatedLinkData,
     PaginatedQueryRunner,
+    PaginationLinkData,
     create_async_session,
     create_database_engine,
     datetime_from_db,
@@ -516,7 +516,7 @@ def test_link_data() -> None:
         '<https://example.com/query>; rel="first", '
         '<https://example.com/query?cursor=1600000000.5_1>; rel="next"'
     )
-    link = PaginatedLinkData.from_header(header)
+    link = PaginationLinkData.from_header(header)
     assert not link.prev_url
     assert link.next_url == "https://example.com/query?cursor=1600000000.5_1"
     assert link.first_url == "https://example.com/query"
@@ -526,7 +526,7 @@ def test_link_data() -> None:
         '<https://example.com/query?limit=10&cursor=15_2>; rel="next", '
         '<https://example.com/query?limit=10&cursor=p5_1>; rel="prev"'
     )
-    link = PaginatedLinkData.from_header(header)
+    link = PaginationLinkData.from_header(header)
     assert link.prev_url == "https://example.com/query?limit=10&cursor=p5_1"
     assert link.next_url == "https://example.com/query?limit=10&cursor=15_2"
     assert link.first_url == "https://example.com/query?limit=10"
@@ -535,18 +535,18 @@ def test_link_data() -> None:
         '<https://example.com/query>; rel="first", '
         '<https://example.com/query?cursor=p1510000000_2>; rel="previous"'
     )
-    link = PaginatedLinkData.from_header(header)
+    link = PaginationLinkData.from_header(header)
     assert link.prev_url == "https://example.com/query?cursor=p1510000000_2"
     assert not link.next_url
     assert link.first_url == "https://example.com/query"
 
     header = '<https://example.com/query?foo=b>; rel="first"'
-    link = PaginatedLinkData.from_header(header)
+    link = PaginationLinkData.from_header(header)
     assert not link.prev_url
     assert not link.next_url
     assert link.first_url == "https://example.com/query?foo=b"
 
-    link = PaginatedLinkData.from_header("")
+    link = PaginationLinkData.from_header("")
     assert not link.prev_url
     assert not link.next_url
     assert not link.first_url


### PR DESCRIPTION
Fix several issues with pagination support uncovered by converting Gafaelfawr to the new approach.

* Document the type parameterization of cursors.
* Document the need to implement `from_entry` for cursors derived from `DatetimeIdCursor`.
* Move cursor parsing into the body of the suggested handler function since FastAPI cannot validate complex models as query parameters.
* Change the pagination exception to a new `InvalidCursorError` instead of `ValueError` since parsing will be done in the handler body and needs to throw an error that can be automatically handled and converted to a 422 HTTP status code.
* Rename `PaginatedLinkData` to `PaginationLinkData` for more correct grammar.
* Drop `DeclarativeBase` from the prototype of `query_object` because tuples are not covariant and this does not pass type checking.
* Document that `query_object` and `query_row` cannot be fully type-checked.