### PR TITLE
DM-47789: Qualify more types in pagination docstrings

### DIFF
--- a/safir/src/safir/database/_pagination.py
+++ b/safir/src/safir/database/_pagination.py
@@ -143,7 +143,7 @@ class PaginationCursor(Generic[E], metaclass=ABCMeta):
 
         Returns
         -------
-        PaginationCursor
+        safir.database.PaginationCursor
             The cursor represented as an object.
 
         Raises
@@ -208,7 +208,7 @@ class PaginationCursor(Generic[E], metaclass=ABCMeta):
 
         Returns
         -------
-        PaginationCursor
+        safir.database.PaginationCursor
             The inverted cursor.
         """
 


### PR DESCRIPTION
Fully-qualify more type references in pagination docstrings to help downstream projects that use Sphinx.