### PR TITLE
DM-47928: Use case-insensitive form middleware for UWS support

### DIFF
--- a/changelog.d/20241203_132727_rra_DM_47928.md
+++ b/changelog.d/20241203_132727_rra_DM_47928.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Case-insensitivity of form `POST` parameters to UWS routes is now handled by middleware, and the `uws_post_params_dependency` function has been removed. Input parameter dependencies for UWS applications can now assume that all parameter keys will be in lowercase.

--- a/safir/src/safir/uws/__init__.py
+++ b/safir/src/safir/uws/__init__.py
@@ -2,7 +2,6 @@
 
 from ._app import UWSApplication
 from ._config import ParametersModel, UWSAppSettings, UWSConfig, UWSRoute
-from ._dependencies import uws_post_params_dependency
 from ._exceptions import (
     DatabaseSchemaError,
     MultiValuedParameterError,
@@ -38,5 +37,4 @@ __all__ = [
     "UWSRoute",
     "UWSSchemaBase",
     "UsageError",
-    "uws_post_params_dependency",
 ]

--- a/safir/src/safir/uws/_app.py
+++ b/safir/src/safir/uws/_app.py
@@ -20,7 +20,10 @@ from safir.database import (
     is_database_current,
     stamp_database_async,
 )
-from safir.middleware.ivoa import CaseInsensitiveQueryMiddleware
+from safir.middleware.ivoa import (
+    CaseInsensitiveFormMiddleware,
+    CaseInsensitiveQueryMiddleware,
+)
 
 from ._config import UWSConfig
 from ._constants import UWS_DATABASE_TIMEOUT, UWS_EXPIRE_JOBS_SCHEDULE
@@ -260,15 +263,17 @@ class UWSApplication:
     def install_middleware(self, app: FastAPI) -> None:
         """Install FastAPI middleware needed by UWS.
 
-        UWS unfortunately requires that the key portion of query parameters be
-        case-insensitive, so UWS FastAPI applications need to add custom
-        middleware to lowercase query parameter keys. This method does that.
+        UWS unfortunately requires that the key portion of query and form
+        parameters be case-insensitive, so UWS FastAPI applications need to
+        add custom middleware to lowercase parameter keys. This method does
+        that.
 
         Parameters
         ----------
         app
             FastAPI app.
         """
+        app.add_middleware(CaseInsensitiveFormMiddleware)
         app.add_middleware(CaseInsensitiveQueryMiddleware)
 
     async def is_schema_current(


### PR DESCRIPTION
Convert the UWS support to the newly-added case-insensitive form middleware, which removes the need for annoying workarounds for case-insensitive form parameters. Update the application documentation accordingly.