### PR TITLE
DM-47986: Fix dependency constraints on Safir modules

### DIFF
--- a/changelog.d/20241211_163506_rra_DM_47986.md
+++ b/changelog.d/20241211_163506_rra_DM_47986.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix dependencies on safir-logging and safir-arq from the safir PyPI module to allow the latest versions to be installed.

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,14 +20,11 @@ nox.options.sessions = [
 nox.options.default_venv_backend = "uv"
 nox.options.reuse_existing_virtualenvs = True
 
-# pip-installable dependencies for all the Safir modules. The local safir-arq
-# apparently has to be installed after safir itself or the safir dependency
-# resolution appears to replace the local install with the safir-arq package
-# from PyPI.
+# pip-installable dependencies for all the Safir modules.
 PIP_DEPENDENCIES = (
-    ("-e", "./safir[arq,db,dev,gcs,kubernetes,redis,uws]"),
-    ("-e", "./safir-logging"),
     ("-e", "./safir-arq"),
+    ("-e", "./safir-logging"),
+    ("-e", "./safir[arq,db,dev,gcs,kubernetes,redis,uws]"),
 )
 
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pydantic-core",
     "pydantic-settings!=2.6.0,<3",
     "python-schema-registry-client>=2.6,<3",
-    "safir-logging<7",
+    "safir-logging",
     "starlette<1",
     "structlog>=21.2.0",
 ]
@@ -43,7 +43,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 arq = [
-    "safir-arq<7",
+    "safir-arq",
 ]
 db = [
     "alembic[tz]<2",
@@ -84,7 +84,7 @@ uws = [
     "google-cloud-storage<3",
     "jinja2<4",
     "python-multipart",
-    "safir-arq<7",
+    "safir-arq",
     "vo-models>=0.4.1,<1",
 ]
 


### PR DESCRIPTION
The main safir PyPI module was constraining the major version of safir-logging and safir-arq, which would break the new UWS support by pinning too old of a version of safir-arq. Those major version constraints are too easy to forget to update, so remove them and instead have Safir pull in the latest version.

Unfortunately, either approach here potentially creates problems down the road. Hopefully this will be the approach that creates fewer issues.