### PR TITLE
DM-47986: Prepare 6.0.1 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/safir"
+      - "/safir-arq"
+      - "/safir-logging"
     schedule:
       interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Changes for the upcoming release can be found in [changelog.d](https://github.co
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-9.0.1'></a>
+## 9.0.1 (2024-12-11)
+
+### Bug fixes
+
+- Fix dependencies on safir-logging and safir-arq from the safir PyPI module to allow the latest versions to be installed.
+
 <a id='changelog-9.0.0'></a>
 ## 9.0.0 (2024-12-11)
 

--- a/changelog.d/20241211_163506_rra_DM_47986.md
+++ b/changelog.d/20241211_163506_rra_DM_47986.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Fix dependencies on safir-logging and safir-arq from the safir PyPI module to allow the latest versions to be installed.

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.11"
 dependencies = [
     "aiokafka>=0.11,<1",
     "click<9",
-    "cryptography<44",
+    "cryptography<45",
     "dataclasses-avroschema>=0.65.3,<1",
     "fastapi<1",
     "faststream>0.5,<0.6",
@@ -59,7 +59,7 @@ dev = [
     "pytest>=6.2.0",
     "pytest-asyncio",
     "pytest-cov",
-    "redis>=5,<6",
+    "redis>=5",
     "respx",
     "scriv",
     "sqlalchemy[mypy]",
@@ -74,7 +74,7 @@ gcs = [
     "google-cloud-storage<3"
 ]
 kubernetes = [
-    "kubernetes_asyncio<31"
+    "kubernetes_asyncio<32"
 ]
 redis = [
     "redis>4.5.2,<6",


### PR DESCRIPTION
Collect change log for 6.0.1 release. Update major version pins on some dependencies and fix the dependabot configuration to detect dependency updates, which was broken when Safir was converted to nox.