### PR TITLE
DM-48173: Remove now-unneeded Black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,20 +5,6 @@
 [tool.black]
 line-length = 79
 target-version = ["py312"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-# Use single-quoted strings so TOML treats the string like a Python r-string
-# Multi-line strings are implicitly treated by black as regular expressions
 
 [tool.mypy]
 disallow_untyped_defs = true


### PR DESCRIPTION
We're now using Ruff for reformatting, so the file ignore patterns for Black are no longer used. Delete them from `pyproject.toml`.