### PR TITLE
DM-48173: Add abstraction for counted paginated queries

### DIFF
--- a/safir/src/safir/database/__init__.py
+++ b/safir/src/safir/database/__init__.py
@@ -17,6 +17,8 @@ from ._initialize import (
     initialize_database,
 )
 from ._pagination import (
+    CountedPaginatedList,
+    CountedPaginatedQueryRunner,
     DatetimeIdCursor,
     InvalidCursorError,
     PaginatedList,
@@ -28,6 +30,8 @@ from ._retry import retry_async_transaction
 
 __all__ = [
     "AlembicConfigError",
+    "CountedPaginatedList",
+    "CountedPaginatedQueryRunner",
     "DatabaseInitializationError",
     "DatetimeIdCursor",
     "InvalidCursorError",


### PR DESCRIPTION
`PaginatedQueryRunner` has a separate `query_count` method to return the count, but since the total entry count isn't included in the `PaginatedList` data structure, it's annoying to pass between components of a service. Either the result plus the count have to be returned as a tuple, or the service has to add its own data structure to wrap `PaginatedList`.

Avoid this by introducing a `CountedPaginatedQueryRunner` and a corresponding `CountedPaginatedList` that always includes a `count` attribute. This can be used by services such as Gafaelfawr that always want to count the total number of entries, either because the table is small or because the count can always be satisfied from the table indices.