### PR TITLE
DM-48760: Simplify if underlying exception has no message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ Changes for the upcoming release can be found in [changelog.d](https://github.co
 
 ### New features
 
-- Sentry instrumentation helpers
-
+- Add a new `safir.sentry` module that provides helper functions and custom exception types for improved Sentry integration.
 - Allow the encryption key to be passed to `safir.redis.EncryptedPydanticRedisStorage` as a `pydantic.SecretStr` instead of `str`. This allows easier integration with secrets that come from Pydantic-parsed settings.
 
 <a id='changelog-9.1.1'></a>

--- a/safir/src/safir/sentry/_exceptions.py
+++ b/safir/src/safir/sentry/_exceptions.py
@@ -88,15 +88,16 @@ class SentryWebException(SentryException):
                 body=exc.response.text,
             )
         else:
-            message = f"{type(exc).__name__}: {exc!s}"
+            exc_name = type(exc).__name__
+            message = f"{exc_name}: {exc!s}" if str(exc) else exc_name
 
             # All httpx.HTTPError exceptions have a slot for the request,
             # initialized to None and then sometimes added by child
             # constructors or during exception processing. The request
             # property is a property method that raises RuntimeError if
-            # request has not been set, so we can't just check for None.
-            # Hence this approach of attempting to use the request and falling
-            # back on reporting less data if that raised any exception.
+            # request has not been set, so we can't just check for None. Hence
+            # this approach of attempting to use the request and falling back
+            # on reporting less data if that raised any exception.
             try:
                 return cls(
                     message,

--- a/safir/src/safir/slack/blockkit.py
+++ b/safir/src/safir/slack/blockkit.py
@@ -358,7 +358,8 @@ class SlackWebException(SlackException):
                 body=exc.response.text,
             )
         else:
-            message = f"{type(exc).__name__}: {exc!s}"
+            exc_name = type(exc).__name__
+            message = f"{exc_name}: {exc!s}" if str(exc) else exc_name
 
             # All httpx.HTTPError exceptions have a slot for the request,
             # initialized to None and then sometimes added by child

--- a/safir/src/safir/slack/blockkit.py
+++ b/safir/src/safir/slack/blockkit.py
@@ -365,9 +365,9 @@ class SlackWebException(SlackException):
             # initialized to None and then sometimes added by child
             # constructors or during exception processing. The request
             # property is a property method that raises RuntimeError if
-            # request has not been set, so we can't just check for None.
-            # Hence this approach of attempting to use the request and falling
-            # back on reporting less data if that raised any exception.
+            # request has not been set, so we can't just check for None. Hence
+            # this approach of attempting to use the request and falling back
+            # on reporting less data if that raised any exception.
             try:
                 return cls(
                     message,


### PR DESCRIPTION
In `SlackWebException.from_exception` and `SentryWebException.from_exception`, the message of the created `SlackWebException` is based on the type name and message of the underlying exception. However, some underlying exceptions, such as timeout errors, may have no message. In that case, drop the trailing colon and space and set the message of `SlackWebException` and `SentryWebException` to only the name of the type of the underlying exception.