### PR TITLE
DM-48819: Use AsyncGenerator over AsyncIterator

### DIFF
--- a/changelog.d/20250206_121830_rra_DM_48819.md
+++ b/changelog.d/20250206_121830_rra_DM_48819.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Declare Safir functions returning async generators with a return type of `AsyncGenerator`, not `AsyncIterator`. In most situations this does not matter, but `AsyncGenerator` has additional methods (such as `aclose`) that `AsyncIterator` does not have and is therefore more correct.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -25,7 +25,7 @@
 .. _Sasquatch: https://sasquatch.lsst.io
 .. _schema registry: https://docs.confluent.io/platform/current/schema-registry/index.html
 .. _scriv: https://scriv.readthedocs.io/en/stable/
-.. _Sentry: https://sentry.io
+.. _Sentry: https://sentry.io/welcome/
 .. _semver: https://semver.org/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _structlog: https://www.structlog.org/en/stable/

--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -26,7 +26,7 @@ In your application's FastAPI setup module, typically :file:`main.py`, you need 
 
 .. code-block:: python
 
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncGenerator
     from contextlib import asynccontextmanager
 
     from fastapi import Depends, FastAPI
@@ -34,7 +34,7 @@ In your application's FastAPI setup module, typically :file:`main.py`, you need 
 
 
     @asynccontextmanager
-    def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         await arq_dependency.initialize(
             mode=config.arq_mode, redis_settings=config.arq_redis_settings
         )

--- a/docs/user-guide/database/dependency.rst
+++ b/docs/user-guide/database/dependency.rst
@@ -14,7 +14,7 @@ You must also close the dependency during application shutdown.
 
 .. code-block:: python
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
    from contextlib import asynccontextmanager
 
    from fastapi import FastAPI
@@ -24,7 +24,7 @@ You must also close the dependency during application shutdown.
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+   async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
        await db_session_dependency.initialize(
            config.database_url, config.database_password
        )

--- a/docs/user-guide/database/schema.rst
+++ b/docs/user-guide/database/schema.rst
@@ -257,7 +257,7 @@ Then, in :file:`main.py`, add code to check the database schema in the applicati
 .. code-block:: python
    :emphasize-lines: 6-7,14-20
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
    from contextlib import asynccontextmanager
 
    import structlog
@@ -269,7 +269,7 @@ Then, in :file:`main.py`, add code to check the database schema in the applicati
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+   async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
        logger = structlog.get_logger("example")
        engine = create_database_engine(
            config.database_url, config.database_password
@@ -300,7 +300,7 @@ This ensures that the checks for the schema will pass when executing tests.
 .. code-block:: python
    :emphasize-lines: 9,26
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
 
    import pytest_asyncio
    from asgi_lifespan import LifespanManager
@@ -317,7 +317,7 @@ This ensures that the checks for the schema will pass when executing tests.
 
 
    @pytest_asyncio.fixture
-   async def app() -> AsyncIterator[FastAPI]:
+   async def app() -> AsyncGenerator[FastAPI]:
        logger = structlog.get_logger(config.logger_name)
        engine = create_database_engine(
            config.database_url, config.database_password

--- a/docs/user-guide/database/testing.rst
+++ b/docs/user-guide/database/testing.rst
@@ -82,7 +82,7 @@ For example:
 
 .. code-block:: python
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
 
    import pytest_asyncio
    from asgi_lifespan import LifespanManager
@@ -95,7 +95,7 @@ For example:
 
 
    @pytest_asyncio.fixture
-   async def app() -> AsyncIterator[FastAPI]:
+   async def app() -> AsyncGenerator[FastAPI]:
        logger = structlog.get_logger(config.logger_name)
        engine = create_database_engine(
            config.database_url, config.database_password

--- a/docs/user-guide/gafaelfawr.rst
+++ b/docs/user-guide/gafaelfawr.rst
@@ -56,7 +56,7 @@ This is most easily done by defining a fixture, as follows.
 
 .. code-block:: python
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
 
    import pytest_asyncio
    from fastapi import FastAPI
@@ -64,7 +64,7 @@ This is most easily done by defining a fixture, as follows.
 
 
    @pytest_asyncio.fixture
-   async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+   async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
        async with AsyncClient(
            transport=ASGITransport(app=app),  # type: ignore[arg-type]
            base_url="https://example.com/",

--- a/docs/user-guide/http-client.rst
+++ b/docs/user-guide/http-client.rst
@@ -15,14 +15,14 @@ This is normally done during the lifespan function for the FastAPI app.
 
 .. code-block:: python
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
    from contextlib import asynccontextmanager
 
    from safir.dependencies.http_client import http_client_dependency
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+   async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
        yield
        await http_client_dependency.aclose()
 
@@ -72,7 +72,7 @@ You can do this in a yield fixture to avoid code duplication.
 
 
    @pytest_asyncio.fixture
-   async def app() -> AsyncIterator[FastAPI]:
+   async def app() -> AsyncGenerator[FastAPI]:
        # Add any other necessary application setup here.
        async with LifespanManager(main.app):
            yield main.app

--- a/docs/user-guide/kubernetes.rst
+++ b/docs/user-guide/kubernetes.rst
@@ -24,7 +24,7 @@ For example:
 
 .. code-block:: python
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
    from contextlib import asynccontextmanager
 
    from fastapi import FastAPI
@@ -32,7 +32,7 @@ For example:
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+   async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
        await initialize_kubernetes()
        yield
 

--- a/docs/user-guide/sentry.rst
+++ b/docs/user-guide/sentry.rst
@@ -90,8 +90,8 @@ And your ``main.py`` might look like this:
 
    app = FastAPI(title="My App", lifespan=lifespan, ...)
 
-.. _before_send: https://docs.sentry.io/platforms/python/configuration/options/#before-send
-.. _traces_sample_rate: https://docs.sentry.io/platforms/python/configuration/options/#traces-sample-rate
+.. _before_send: https://docs.sentry.io/platforms/python/configuration/options/#before_send
+.. _traces_sample_rate: https://docs.sentry.io/platforms/python/configuration/options/#traces_sample_rate
 .. _configuration options: https://docs.sentry.io/platforms/python/configuration/options/
 
 .. _sentry-exception-types:

--- a/docs/user-guide/sentry.rst
+++ b/docs/user-guide/sentry.rst
@@ -85,7 +85,7 @@ And your ``main.py`` might look like this:
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator: ...
+   async def lifespan(app: FastAPI) -> AsyncGenerator: ...
 
 
    app = FastAPI(title="My App", lifespan=lifespan, ...)

--- a/docs/user-guide/uws/create-a-service.rst
+++ b/docs/user-guide/uws/create-a-service.rst
@@ -102,7 +102,7 @@ First, initialize and shut down the UWS application in the ``lifespan`` function
 
 
    @asynccontextmanager
-   async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+   async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
        await uws.initialize_fastapi()
        yield
        await uws.shutdown_fastapi()

--- a/docs/user-guide/uws/testing.rst
+++ b/docs/user-guide/uws/testing.rst
@@ -87,7 +87,9 @@ Finally, configure the ``client`` fixture to send the appropriate headers by def
 
 .. code-block:: python
    :caption: tests/conftest.py
-   :emphasize-lines: 8,13-16
+   :emphasize-lines: 10,15-18
+
+   from collections.abc import AsyncGenerator
 
    import pytest
    from fastapi import FastAPI
@@ -97,7 +99,7 @@ Finally, configure the ``client`` fixture to send the appropriate headers by def
    @pytest_asyncio.fixture
    async def client(
        app: FastAPI, test_token: str, test_username: str
-   ) -> AsyncIterator[AsyncClient]:
+   ) -> AsyncGenerator[AsyncClient]:
        async with AsyncClient(
            transport=ASGITransport(app=app),
            base_url="https://example.com/",
@@ -139,7 +141,7 @@ Then, configure the application to use that arq queue instead of the default one
    :caption: tests/conftest.py
    :emphasize-lines: 8,14
 
-   from collections.abc import AsyncIterator
+   from collections.abc import AsyncGenerator
 
    from asgi_lifespan import LifespanManager
    from fastapi import FastAPI
@@ -150,7 +152,7 @@ Then, configure the application to use that arq queue instead of the default one
 
 
    @pytest_asyncio.fixture
-   async def app(arq_queue: MockArqQueue) -> AsyncIterator[FastAPI]:
+   async def app(arq_queue: MockArqQueue) -> AsyncGenerator[FastAPI]:
        async with LifespanManager(main.app):
            uws.override_arq_queue(arq_queue)
            yield main.app

--- a/safir/src/safir/asyncio/_multiqueue.py
+++ b/safir/src/safir/asyncio/_multiqueue.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from datetime import timedelta
 from types import EllipsisType
 from typing import Generic, TypeVar
@@ -44,7 +44,7 @@ class AsyncMultiQueue(Generic[T]):
         self._contents: list[T | EllipsisType] = []
         self._triggers: list[asyncio.Event] = []
 
-    def __aiter__(self) -> AsyncIterator[T]:
+    def __aiter__(self) -> AsyncGenerator[T]:
         """Return an async iterator over the queue."""
         return self.aiter_from(0)
 
@@ -60,7 +60,7 @@ class AsyncMultiQueue(Generic[T]):
 
     def aiter_from(
         self, start: int, timeout: timedelta | None = None
-    ) -> AsyncIterator[T]:
+    ) -> AsyncGenerator[T]:
         """Return an async iterator over the queue.
 
         Each call to this function returns a separate iterator over the same
@@ -79,8 +79,8 @@ class AsyncMultiQueue(Generic[T]):
 
         Returns
         -------
-        AsyncIterator
-            An async iterator over the contents of the queue.
+        AsyncGenerator
+            An async generator over the contents of the queue.
 
         Raises
         ------
@@ -103,7 +103,7 @@ class AsyncMultiQueue(Generic[T]):
         # Construct the iterator, which waits for the trigger and returns any
         # new events until it sees the placeholder for the end of the queue
         # (the ellipsis object).
-        async def iterator() -> AsyncIterator[T]:
+        async def iterator() -> AsyncGenerator[T]:
             position = start
             try:
                 while True:

--- a/safir/src/safir/dependencies/arq.py
+++ b/safir/src/safir/dependencies/arq.py
@@ -43,7 +43,7 @@ class ArqDependency:
         --------
         .. code-block:: python
 
-           from collections.abc import AsyncIterator
+           from collections.abc import AsyncGenerator
            from contextlib import asynccontextmanager
 
            from fastapi import Depends, FastAPI
@@ -52,7 +52,7 @@ class ArqDependency:
 
 
            @asynccontextmanager
-           async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+           async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                await arq_dependency.initialize(mode=ArqMode.test)
                yield
 

--- a/safir/src/safir/dependencies/db_session.py
+++ b/safir/src/safir/dependencies/db_session.py
@@ -1,6 +1,6 @@
 """Manage an async database session."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 
 from pydantic import SecretStr
 from pydantic_core import Url
@@ -41,7 +41,7 @@ class DatabaseSessionDependency:
         self._engine: AsyncEngine | None = None
         self._session: async_scoped_session | None = None
 
-    async def __call__(self) -> AsyncIterator[async_scoped_session]:
+    async def __call__(self) -> AsyncGenerator[async_scoped_session]:
         """Return the database session manager.
 
         Returns

--- a/safir/src/safir/dependencies/http_client.py
+++ b/safir/src/safir/dependencies/http_client.py
@@ -32,14 +32,14 @@ class HTTPClientDependency:
 
     .. code-block:: python
 
-       from collections.abc import AsyncIterator
+       from collections.abc import AsyncGenerator
        from contextlib import asynccontextmanager
 
        from fastapi import FastAPI
 
 
        @asynccontextmanager
-       async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+       async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
            yield
            await http_client_dependency.aclose()
 

--- a/safir/src/safir/redis/_storage.py
+++ b/safir/src/safir/redis/_storage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Generic, TypeVar
 
 try:
@@ -143,7 +143,7 @@ class PydanticRedisStorage(Generic[S]):
             msg = f"Cannot deserialize data for key {full_key}"
             raise DeserializeError(msg, key=full_key, error=error) from e
 
-    async def scan(self, pattern: str) -> AsyncIterator[str]:
+    async def scan(self, pattern: str) -> AsyncGenerator[str]:
         """Scan Redis for a given key pattern, returning each key.
 
         Parameters

--- a/safir/src/safir/testing/kubernetes.py
+++ b/safir/src/safir/testing/kubernetes.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 from collections import defaultdict
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
 from datetime import timedelta
 from typing import Any, Protocol
 from unittest.mock import AsyncMock, Mock, patch
@@ -284,7 +284,7 @@ class _EventStream:
         timeout_seconds: int | None,
         field_selector: str | None,
         label_selector: str | None,
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes]:
         """Construct a watcher for this event stream.
 
         Parameters
@@ -307,7 +307,7 @@ class _EventStream:
 
         Returns
         -------
-        AsyncIterator
+        AsyncGenerator
             An async iterator that will return each new event in the stream,
             encoded as expected by the Kubernetes API, until the timeout
             occurs.
@@ -330,7 +330,7 @@ class _EventStream:
             name = match.group(1)
 
         # Construct the iterator.
-        async def next_event() -> AsyncIterator[bytes]:
+        async def next_event() -> AsyncGenerator[bytes]:
             if resource_version:
                 start = int(resource_version)
             else:

--- a/safir/tests/conftest.py
+++ b/safir/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Generator, Iterator
+from collections.abc import AsyncGenerator, Generator, Iterator
 from datetime import timedelta
 from pathlib import Path
 
@@ -117,7 +117,7 @@ def kafka_connection_settings(
 @pytest_asyncio.fixture
 async def kafka_consumer(
     kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncIterator[AIOKafkaConsumer]:
+) -> AsyncGenerator[AIOKafkaConsumer]:
     """Provide an AOIKafkaConsumer pointed at a session-scoped kafka container.
 
     All data is cleared from the kafka instance at the end of the test.
@@ -134,7 +134,7 @@ async def kafka_consumer(
 @pytest_asyncio.fixture
 async def kafka_broker(
     kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncIterator[KafkaBroker]:
+) -> AsyncGenerator[KafkaBroker]:
     """Provide a fast stream KafkaBroker pointed at a session-scoped kafka
     container.
 
@@ -152,7 +152,7 @@ async def kafka_broker(
 @pytest_asyncio.fixture
 async def kafka_admin_client(
     kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncIterator[AIOKafkaAdminClient]:
+) -> AsyncGenerator[AIOKafkaAdminClient]:
     """Provide an AOIKafkaAdmin client pointed at a session-scoped kafka
     container.
 
@@ -224,7 +224,7 @@ def schema_manager(
 async def event_manager(
     kafka_connection_settings: KafkaConnectionSettings,
     schema_manager_settings: SchemaManagerSettings,
-) -> AsyncIterator[EventManager]:
+) -> AsyncGenerator[EventManager]:
     """Provide an event manager and create a matching Kafka topic."""
     config = KafkaMetricsConfiguration(
         application="testapp",
@@ -285,7 +285,7 @@ def redis() -> Iterator[RedisContainer]:
 
 
 @pytest_asyncio.fixture
-async def redis_client(redis: RedisContainer) -> AsyncIterator[Redis]:
+async def redis_client(redis: RedisContainer) -> AsyncGenerator[Redis]:
     """Create a Redis client for testing.
 
     This must be done separately for each test since it's tied to the per-test

--- a/safir/tests/dependencies/arq_test.py
+++ b/safir/tests/dependencies/arq_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
@@ -17,7 +17,7 @@ from safir.dependencies.arq import arq_dependency
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await arq_dependency.initialize(mode=ArqMode.test, redis_settings=None)
     yield
 

--- a/safir/tests/dependencies/http_client_test.py
+++ b/safir/tests/dependencies/http_client_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Annotated
 
@@ -21,7 +21,7 @@ def non_mocked_hosts() -> list[str]:
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     yield
     await http_client_dependency.aclose()
 

--- a/safir/tests/uws/conftest.py
+++ b/safir/tests/uws/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, Iterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 
@@ -34,7 +34,7 @@ async def app(
     mock_wobbly: MockWobbly,
     uws_config: UWSConfig,
     logger: BoundLogger,
-) -> AsyncIterator[FastAPI]:
+) -> AsyncGenerator[FastAPI]:
     """Return a configured test application for UWS.
 
     This is a stand-alone test application independent of any real web
@@ -45,7 +45,7 @@ async def app(
     uws.override_arq_queue(arq_queue)
 
     @asynccontextmanager
-    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         await uws.initialize_fastapi()
         yield
         await uws.shutdown_fastapi()
@@ -70,7 +70,7 @@ def arq_queue() -> MockArqQueue:
 @pytest_asyncio.fixture
 async def client(
     app: FastAPI, test_token: str, test_username: str
-) -> AsyncIterator[AsyncClient]:
+) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app),


### PR DESCRIPTION
In all places where the function returns an async generator rather than an async iterator (which is all cases in Safir), correctly type them as returning `AsyncGenerator`, not `AsyncIterator`. In most cases this won't matter, but `AsyncGenerator` has additional methods such as `aclose`.