### PR TITLE
DM-48838: Add ServiceAccount to Kubernetes mock

### DIFF
--- a/changelog.d/20250207_155019_rra_DM_48838.md
+++ b/changelog.d/20250207_155019_rra_DM_48838.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add create, delete, read, and list (with watches) support for `ServiceAccount` objects to the mock Kubernetes API.


### PR DESCRIPTION
Add create, delete, read, and list (with watches) support for `ServiceAccount` objects to the mock Kubernetes API.