### PR TITLE
DM-48838: Add object creation callbacks to Kubernetes mock

### DIFF
--- a/changelog.d/20250210_173334_rra_DM_48838.md
+++ b/changelog.d/20250210_173334_rra_DM_48838.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `register_create_hook_for_test` method on the mock Kubernetes API that allows the caller to register a callback that is called whenever an object of a given kind is created.

--- a/docs/user-guide/kubernetes.rst
+++ b/docs/user-guide/kubernetes.rst
@@ -191,3 +191,12 @@ The data stored in :file:`tests/data/pod.json` can then contain only the interes
 
    As in the above example, consider passing ``serialize=True`` whenever calling the ``to_dict`` method on a Kubernetes model.
    This tells the Kubernetes library to use the correct Kubernetes camel-case attribute names rather than the Python snake-case attribute names.
+
+Performing actions after object creation
+----------------------------------------
+
+Safir supports registering a callback that is called after object creation.
+To do this, call `~safir.testing.kubernetes.MockKubernetesApi.register_create_hook_for_test` with the kind of the object and the callback.
+Whenever an object of that kind is created, the callback will be called.
+
+This can be used to simulate such Kubernetes behavior as the creation of a default service account for a namespace, or assigning an IP address to an ingress.


### PR DESCRIPTION
Refactor the Kubernetes mock to move more code into shared internal methods, most notably publication of internal events that is used for the watch support. Add support for a callback after object creation that can be used for things like creating the default service account for a namespace when the namespace is created.