### PR TITLE
DM:48838: Add __all__ to safir.sentry._exceptions

### DIFF
--- a/safir/src/safir/fastapi/_errors.py
+++ b/safir/src/safir/fastapi/_errors.py
@@ -147,7 +147,7 @@ class ClientRequestError(SlackIgnoredException):
         self.field_path = field_path
 
     def to_dict(self) -> dict[str, list[str] | str]:
-        """Convert the exception to a dictionary suitable for the exception.
+        """Convert the exception to a dictionary suitable for the response.
 
         Returns
         -------

--- a/safir/src/safir/sentry/_exceptions.py
+++ b/safir/src/safir/sentry/_exceptions.py
@@ -5,14 +5,16 @@ from typing import Any, Self
 from httpx import HTTPError, HTTPStatusError
 from sentry_sdk.types import Event
 
+__all__ = [
+    "SentryException",
+    "SentryWebException",
+]
+
 
 class SentryException(Exception):
     """Enriches the Sentry context when paired with the ``enrich`` handler."""
 
-    def __init__(
-        self,
-        message: str,
-    ) -> None:
+    def __init__(self, message: str) -> None:
         # Do not call the parent Exception constructor here, because calling
         # it with a different number of arguments than the constructor
         # argument of derived exceptions breaks pickling. See the end of


### PR DESCRIPTION
Add missing `__all__` variable to `safir.sentry._exceptions` and reformat the `__init__` method of `SentryException`.