### PR TITLE
DM-48838: Use current_datetime in fewer places

### DIFF
--- a/safir/src/safir/asyncio/_multiqueue.py
+++ b/safir/src/safir/asyncio/_multiqueue.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from types import EllipsisType
 from typing import Generic, TypeVar
-
-from safir.datetime import current_datetime
 
 #: Type variable of objects being stored in `AsyncMultiQueue`.
 T = TypeVar("T")
@@ -87,10 +85,7 @@ class AsyncMultiQueue(Generic[T]):
         TimeoutError
             Raised when the timeout is reached.
         """
-        if timeout:
-            end_time = current_datetime(microseconds=True) + timeout
-        else:
-            end_time = None
+        end_time = datetime.now(tz=UTC) + timeout if timeout else None
 
         # Grab a reference to the current contents so that the iterator
         # detaches from the contents on clear.
@@ -118,7 +113,7 @@ class AsyncMultiQueue(Generic[T]):
                     elif contents and contents[-1] is Ellipsis:
                         return
                     if end_time:
-                        now = current_datetime(microseconds=True)
+                        now = datetime.now(tz=UTC)
                         timeout_left = (end_time - now).total_seconds()
                         async with asyncio.timeout(timeout_left):
                             await trigger.wait()

--- a/safir/src/safir/sentry/_helpers.py
+++ b/safir/src/safir/sentry/_helpers.py
@@ -1,11 +1,11 @@
 """Sentry helpers."""
 
-from datetime import timedelta
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
 
 from sentry_sdk.tracing import Span
 from sentry_sdk.types import Event, Hint
-
-from safir.datetime import current_datetime
 
 from ._exceptions import SentryException
 
@@ -20,10 +20,9 @@ __all__ = [
 def duration(span: Span) -> timedelta:
     """Return the time spent in a span (to the present if not finished)."""
     if span.timestamp is None:
-        timestamp = current_datetime(microseconds=True)
+        timestamp = datetime.now(tz=UTC)
     else:
         timestamp = span.timestamp
-
     return timestamp - span.start_timestamp
 
 

--- a/safir/src/safir/slack/blockkit.py
+++ b/safir/src/safir/slack/blockkit.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, ClassVar, Self
 
 from httpx import HTTPError, HTTPStatusError
 from pydantic import BaseModel, field_validator
 
-from safir.datetime import current_datetime, format_datetime_for_logging
+from safir.datetime import format_datetime_for_logging
 
 __all__ = [
     "SlackBaseBlock",
@@ -275,10 +275,7 @@ class SlackException(Exception):
         # fix. See https://github.com/python/cpython/issues/76877.
         self.message = message
         self.user = user
-        if failed_at:
-            self.failed_at = failed_at
-        else:
-            self.failed_at = current_datetime(microseconds=True)
+        self.failed_at = failed_at if failed_at else datetime.now(tz=UTC)
 
     def __str__(self) -> str:
         return self.message


### PR DESCRIPTION
Replace calls to `current_datetime(microseconds=True)` with the standard `datetime.now(tz=UTC)`, which was added in 3.11 and is shorter and more familiar.