### PR TITLE
DM-48838: Move model_config to the start of classes

### DIFF
--- a/docs/user-guide/pydantic.rst
+++ b/docs/user-guide/pydantic.rst
@@ -35,12 +35,12 @@ For example:
 
 
    class Config(BaseSettings):
-       database_url: EnvAsyncPostgresDsn
-       redis_url: EnvRedisDsn
-
        model_config = SettingsConfigDict(
            env_prefix="EXAMPLE_", case_sensitive=False
        )
+
+       database_url: EnvAsyncPostgresDsn
+       redis_url: EnvRedisDsn
 
 These types only adjust DSNs initialized as normal.
 They do not synthesize DSNs if none are set.
@@ -150,11 +150,11 @@ To use it, add a configuration block to any Pydantic model that has snake-case a
 
 
    class Model(BaseModel):
-       some_field: str
-
        model_config = ConfigDict(
            alias_generator=to_camel_case, populate_by_name=True
        )
+
+       some_field: str
 
 By default, only the generated aliases (so, in this case, only the camel-case form of the attribute, ``someField``) are supported.
 The additional setting ``allow_population_by_field_name``, tells Pydantic to allow either ``some_field`` or ``someField`` in the input.

--- a/safir/src/safir/kafka/_kafka_config.py
+++ b/safir/src/safir/kafka/_kafka_config.py
@@ -309,6 +309,10 @@ class KafkaConnectionSettings(BaseSettings):
        blah = config.validated.sasl_username  # Static type error
     """
 
+    model_config = SettingsConfigDict(
+        case_sensitive=False, extra="forbid", populate_by_name=True
+    )
+
     bootstrap_servers: str = Field(
         title="Kafka bootstrap servers",
         description=(
@@ -409,10 +413,6 @@ class KafkaConnectionSettings(BaseSettings):
             "protocols."
         ),
         validation_alias=AliasChoices("saslPassword", "KAFKA_SASL_PASSWORD"),
-    )
-
-    model_config = SettingsConfigDict(
-        case_sensitive=False, extra="forbid", populate_by_name=True
     )
 
     @model_validator(mode="after")

--- a/safir/src/safir/kafka/_schema_registry_config.py
+++ b/safir/src/safir/kafka/_schema_registry_config.py
@@ -27,6 +27,13 @@ class SchemaRegistryClientParams(TypedDict):
 class SchemaManagerSettings(BaseSettings):
     """Settings for constructing a `~safir.kafka.PydanticSchemaManager`."""
 
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        env_prefix="SCHEMA_MANAGER_",
+        extra="forbid",
+        populate_by_name=True,
+    )
+
     registry_url: AnyUrl = Field(
         title="Schema registry URL",
         description="URL of a a Confluent-compatible schema registry",
@@ -46,13 +53,6 @@ class SchemaManagerSettings(BaseSettings):
             " production, it's best to not set a suffix."
         ),
         examples=["_dev1"],
-    )
-
-    model_config = SettingsConfigDict(
-        case_sensitive=False,
-        env_prefix="SCHEMA_MANAGER_",
-        extra="forbid",
-        populate_by_name=True,
     )
 
     def to_registry_params(self) -> SchemaRegistryClientParams:

--- a/safir/src/safir/pydantic/_camel.py
+++ b/safir/src/safir/pydantic/_camel.py
@@ -41,11 +41,11 @@ def to_camel_case(string: str) -> str:
     .. code-block:: python
 
        class Model(BaseModel):
-           some_field: str
-
            model_config = ConfigDict(
                alias_generator=to_camel_case, populate_by_name=True
            )
+
+           some_field: str
 
     This must be added to every class that uses ``snake_case`` for an
     attribute and that needs to be initialized from ``camelCase``.

--- a/safir/tests/support/alembic.py
+++ b/safir/tests/support/alembic.py
@@ -26,11 +26,11 @@ class Config(BaseSettings):
     ``TEST_DATABASE_PASSWORD`` to match the database that it should use.
     """
 
+    model_config = SettingsConfigDict(env_prefix="TEST_", case_sensitive=False)
+
     database_url: EnvAsyncPostgresDsn = Url("postgresql://localhost/safir")
     database_password: SecretStr = SecretStr("INSECURE")
     log_level: LogLevel = LogLevel.DEBUG
-
-    model_config = SettingsConfigDict(env_prefix="TEST_", case_sensitive=False)
 
 
 config = Config()


### PR DESCRIPTION
For Pydantic classes with a custom model configuration, set the model configuration at the start of the class instead of at the end. It changes a lot of behavior, and putting it at the top makes it more obvious.