### PR TITLE
DM-48838: Avoid sqlalchemy.future

### DIFF
--- a/safir/tests/dependencies/db_session_test.py
+++ b/safir/tests/dependencies/db_session_test.py
@@ -8,9 +8,8 @@ import pytest
 import structlog
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import String
+from sqlalchemy import String, select
 from sqlalchemy.ext.asyncio import async_scoped_session
-from sqlalchemy.future import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from safir.database import (


### PR DESCRIPTION
Since the 2.0.0 release, there is no longer a need to impor the new sqlalchemy API from sqlalchemy.future.