### PR TITLE
DM-48838: Prepare 6.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Changes for the upcoming release can be found in [changelog.d](https://github.co
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-9.3.0'></a>
+## 9.3.0 (2025-02-11)
+
+### New features
+
+- Add new `register_create_hook_for_test` method on the mock Kubernetes API that allows the caller to register a callback that is called whenever an object of a given kind is created.
+- Add create, delete, read, and list (with watches) support for `ServiceAccount` objects to the mock Kubernetes API.
+
+### Bug fixes
+
+- Declare Safir functions returning async generators with a return type of `AsyncGenerator`, not `AsyncIterator`. In most situations this does not matter, but `AsyncGenerator` has additional methods (such as `aclose`) that `AsyncIterator` does not have and is therefore more correct.
+
 <a id='changelog-9.2.0'></a>
 ## 9.2.0 (2025-01-22)
 

--- a/changelog.d/20250206_121830_rra_DM_48819.md
+++ b/changelog.d/20250206_121830_rra_DM_48819.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Declare Safir functions returning async generators with a return type of `AsyncGenerator`, not `AsyncIterator`. In most situations this does not matter, but `AsyncGenerator` has additional methods (such as `aclose`) that `AsyncIterator` does not have and is therefore more correct.

--- a/changelog.d/20250207_155019_rra_DM_48838.md
+++ b/changelog.d/20250207_155019_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add create, delete, read, and list (with watches) support for `ServiceAccount` objects to the mock Kubernetes API.

--- a/changelog.d/20250210_173334_rra_DM_48838.md
+++ b/changelog.d/20250210_173334_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add new `register_create_hook_for_test` method on the mock Kubernetes API that allows the caller to register a callback that is called whenever an object of a given kind is created.

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "click<9",
     "cryptography<45",
     "dataclasses-avroschema>=0.65.7,<1",
-    "fastapi<1",
+    "fastapi>=0.100,<1",
     "faststream>0.5,<0.6",
     "gidgethub<6",
     "httpx>=0.20.0,<1",


### PR DESCRIPTION
Collect the change log for the 6.3.0 release. Put a lower bound on the FastAPI dependency to ensure that an ancient version of FastAPI with no bounded Pydantic dependency is not eligible.