### PR TITLE
DM-49036: Increase minimum Python version to 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ env:
   # Default Python version used for all jobs other than test, which uses a
   # matrix of supported versions. Quote the version to avoid interpretation as
   # a floating point number.
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13"
 
 "on":
   merge_group: {}
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.11"
           - "3.12"
           - "3.13"
 

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -9,7 +9,7 @@ env:
   # Default Python version used for all jobs other than test, which uses a
   # matrix of supported versions. Quote the version to avoid interpretation as
   # a floating point number.
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13"
 
 "on":
   schedule:
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.11"
           - "3.12"
           - "3.13"
 

--- a/changelog.d/20250219_101859_rra_DM_49036.md
+++ b/changelog.d/20250219_101859_rra_DM_49036.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Safir now requires a minimum Python version of 3.12.

--- a/docs/user-guide/uws/write-backend.rst
+++ b/docs/user-guide/uws/write-backend.rst
@@ -185,7 +185,7 @@ The backend worker will generally use a separate Docker image from the frontend 
 This allows it to use a different software stack, such as the Science Pipelines Docker image.
 You will then need to install the backend worker code and its prerequisites so that it's suitable for use as an arq worker.
 
-The backend worker image must have a suitable Python 3.11 or later with Pydantic_ and structlog_.
+The backend worker image must have a suitable Python 3.12 or later with Pydantic_ and structlog_.
 On top of this, install the safir-arq PyPI package, which contains just the portions of Safir required to talk to arq and create a backend worker, and the safir-logging PyPI package, which contains the code to configure structlog.
 
 Finally, install your application, but without its dependencies.

--- a/safir-arq/pyproject.toml
+++ b/safir-arq/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
@@ -22,7 +21,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "arq>=0.23,<1",
     "pydantic>2,<3",

--- a/safir-logging/pyproject.toml
+++ b/safir-logging/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
@@ -22,7 +21,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     # 23.3.0 excluded due to https://github.com/hynek/structlog/issues/584
     "structlog>=21.2.0,!=23.3.0",

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
@@ -22,7 +21,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "aiokafka>=0.11,<1",
     "click<9",


### PR DESCRIPTION
Now that the stack containers have switched to Python 3.12, drop support for Python 3.11. Use Python 3.13 for the portions of GitHub Actions that do not need to use a matrix of Python versions.