### PR TITLE
DM-49036: Switch to new syntax for generics

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -9,6 +9,7 @@ package = "safir"
 rst_epilog_file = "_rst_epilog.rst"
 nitpicky = true
 nitpick_ignore_regex = [
+    ['py:.*', 'dataclasses_avroschema.*'],
     ['py:.*', 'faststream.*'],
     ['py:.*', 'fastapi.*'],
     ['py:.*', 'kubernetes_asyncio.*'],
@@ -16,9 +17,10 @@ nitpick_ignore_regex = [
     ['py:.*', 'pydantic.*'],
     ['py:.*', 'respx.*'],
     ['py:.*', 'starlette.*'],
-    # Bug in autodoc_pydantic re: models with validators
+    # autodoc_pydantic does not handle validators or Annotated correctly.
     ["py:obj", ".*\\.all fields"],
-    ['py:.*', 'dataclasses_avroschema.*'],
+    ["py:obj", "lambda.*"],
+    ["py:obj", "ExecutionPhase.*"]
 ]
 nitpick_ignore = [
     # These don't appear to have documentation but show up in the inheritance
@@ -30,6 +32,7 @@ nitpick_ignore = [
     ['py:class', 'unittest.mock.CallableMixin'],
     ["py:obj", "ComputedFieldInfo"],
     ["py:class", "lambda"],
+    ["py:obj", "typing.P"],
     # arq doesn't provide documentation for all of its types.
     ["py:class", "arq.cron.CronJob"],
     ["py:class", "arq.typing.StartupShutdown"],
@@ -43,17 +46,6 @@ nitpick_ignore = [
     ["py:obj", "safir.pydantic.IvoaIsoDatetime"],
     ["py:obj", "safir.pydantic.SecondsTimedelta"],
     ["py:obj", "safir.pydantic.UtcDatetime"],
-    # TypeVar references used as parameters to Generic seem to create target
-    # not found errors even if they are exported when they are used in private
-    # submodules.
-    ["py:obj", "safir.asyncio._multiqueue.T"],
-    ["py:obj", "safir.asyncio._run.F"],
-    ["py:obj", "safir.asyncio._run.P"],
-    ["py:obj", "safir.database._pagination.C"],
-    ["py:obj", "safir.database._pagination.E"],
-    ["py:obj", "safir.redis._storage.S"],
-    ["py:obj", "safir.metrics._event_manager.P"],
-    ["py:obj", "safir.metrics._testing.P"],
     # SQLAlchemy DeclarativeBase documentation has references that Sphinx
     # can't resolve properly.
     ["py:class", "sqlalchemy.inspection.Inspectable"],
@@ -61,7 +53,8 @@ nitpick_ignore = [
     ["py:class", "_orm.registry"],
     ["py:class", "_schema.MetaData"],
     ["py:class", "_schema.Table"],
-    # See https://github.com/sphinx-doc/sphinx/issues/13178
+    # See https://github.com/sphinx-doc/sphinx/issues/13178 which, although
+    # closed, appears to still not be fixed
     ["py:class", "pathlib._local.Path"],
     # The AOIKafkaAdminClient is considered experimental and not officially
     # exported

--- a/safir-arq/src/safir/arq/uws.py
+++ b/safir-arq/src/safir/arq/uws.py
@@ -1,7 +1,5 @@
 """Construction of UWS backend workers."""
 
-from __future__ import annotations
-
 import asyncio
 import os
 import signal
@@ -12,7 +10,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from traceback import format_exception
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar
 from urllib.parse import urlsplit
 
 from arq import func
@@ -22,15 +20,11 @@ from structlog.stdlib import BoundLogger
 
 from . import ArqMode, ArqQueue, MockArqQueue, RedisArqQueue, WorkerSettings
 
-T = TypeVar("T", bound="BaseModel")
-"""Type for job parameters."""
-
 UWS_QUEUE_NAME = "uws:queue"
 """Name of the arq queue for internal UWS messages."""
 
 __all__ = [
     "UWS_QUEUE_NAME",
-    "T",
     "WorkerConfig",
     "WorkerError",
     "WorkerErrorType",
@@ -45,7 +39,7 @@ __all__ = [
 
 
 @dataclass
-class WorkerConfig(Generic[T]):
+class WorkerConfig[T: BaseModel]:
     """Minimal configuration needed for building a UWS backend worker."""
 
     arq_mode: ArqMode
@@ -269,7 +263,7 @@ def _restart_pool(pool: ProcessPoolExecutor) -> ProcessPoolExecutor:
     return ProcessPoolExecutor(1)
 
 
-def build_worker(
+def build_worker[T: BaseModel](
     worker: Callable[[T, WorkerJobInfo, BoundLogger], list[WorkerResult]],
     config: WorkerConfig[T],
     logger: BoundLogger,

--- a/safir/src/safir/asyncio/_multiqueue.py
+++ b/safir/src/safir/asyncio/_multiqueue.py
@@ -1,20 +1,13 @@
 """An asyncio multiple reader, multiple writer queue."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from types import EllipsisType
-from typing import Generic, TypeVar
-
-#: Type variable of objects being stored in `AsyncMultiQueue`.
-T = TypeVar("T")
 
 __all__ = [
     "AsyncMultiQueue",
     "AsyncMultiQueueError",
-    "T",
 ]
 
 
@@ -22,7 +15,7 @@ class AsyncMultiQueueError(Exception):
     """Invalid sequence of calls when writing to `AsyncMultiQueue`."""
 
 
-class AsyncMultiQueue(Generic[T]):
+class AsyncMultiQueue[T]:
     """An asyncio multiple reader, multiple writer queue.
 
     Provides a generic queue for asyncio that supports multiple readers (via

--- a/safir/src/safir/asyncio/_run.py
+++ b/safir/src/safir/asyncio/_run.py
@@ -1,26 +1,13 @@
 """A decorator to run a function under `asyncio.run`."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import ParamSpec, TypeVar
 
-#: Parameter spec for functions decorated by `run_with_asyncio`.
-P = ParamSpec("P")
-
-#: Type variable for return type of decorated by `run_with_asyncio`.
-F = TypeVar("F")
-
-__all__ = [
-    "F",
-    "P",
-    "run_with_asyncio",
-]
+__all__ = ["run_with_asyncio"]
 
 
-def run_with_asyncio(
+def run_with_asyncio[**P, F](
     f: Callable[P, Coroutine[None, None, F]],
 ) -> Callable[P, F]:
     """Run the decorated function with `asyncio.run`.

--- a/safir/src/safir/dependencies/metrics.py
+++ b/safir/src/safir/dependencies/metrics.py
@@ -1,16 +1,13 @@
 """Dependencies for metrics functionality."""
 
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
 
 from safir.metrics import EventManager
 
-__all__ = ["E", "EventDependency", "EventMaker"]
-
-E = TypeVar("E", bound="EventMaker")
-"""Generic event maker type."""
+__all__ = [
+    "EventDependency",
+    "EventMaker",
+]
 
 
 class EventMaker(ABC):
@@ -30,7 +27,7 @@ class EventMaker(ABC):
         """
 
 
-class EventDependency(Generic[E]):
+class EventDependency[E: EventMaker]:
     """Provides EventManager-managed events for apps to publish.
 
     Parameters

--- a/safir/src/safir/kafka/_manager.py
+++ b/safir/src/safir/kafka/_manager.py
@@ -11,7 +11,7 @@ import inspect
 import re
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, TypeVar
+from typing import Any
 
 import structlog
 from dataclasses_avroschema.pydantic import AvroBaseModel
@@ -33,8 +33,6 @@ __all__ = [
     "PydanticSchemaManager",
     "SchemaInfo",
 ]
-
-P = TypeVar("P", bound=AvroBaseModel)
 
 
 class Compatibility(StrEnum):

--- a/safir/src/safir/metrics/_testing.py
+++ b/safir/src/safir/metrics/_testing.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from pprint import pformat
-from typing import Any, Generic, TypeAlias, TypeVar, override
+from typing import Any, TypeAlias, override
 from unittest.mock import ANY as MOCK_ANY
 
 from ._models import EventPayload
@@ -17,9 +17,6 @@ __all__ = [
     "PublishedList",
     "PublishedTooFewError",
 ]
-
-P = TypeVar("P", bound=EventPayload)
-"""Generic event payload type."""
 
 ANY = MOCK_ANY
 """An object that compares equal to anything, reexported from unittest.mock."""
@@ -42,7 +39,7 @@ NOT_NONE = _NotNone()
 """An object to indicate that a value can be anything except None."""
 
 
-class BaseAssertionError(Generic[P], ABC, AssertionError):
+class BaseAssertionError[P: EventPayload](ABC, AssertionError):
     """Base assertion error with common attributes and messaging."""
 
     def __init__(
@@ -69,7 +66,7 @@ class BaseAssertionError(Generic[P], ABC, AssertionError):
         """Return a string to be added to the exception message."""
 
 
-class PublishedTooFewError(BaseAssertionError):
+class PublishedTooFewError[P: EventPayload](BaseAssertionError[P]):
     """Expected more events than have actually been published."""
 
     @override
@@ -77,7 +74,7 @@ class PublishedTooFewError(BaseAssertionError):
         return "Expected more events than have actually been published"
 
 
-class PublishedCountError(BaseAssertionError):
+class PublishedCountError[P: EventPayload](BaseAssertionError[P]):
     """Expected has a different number of items than were published."""
 
     @override
@@ -85,7 +82,7 @@ class PublishedCountError(BaseAssertionError):
         return "Expected has a different number of items than were published"
 
 
-class NotPublishedConsecutivelyError(BaseAssertionError):
+class NotPublishedConsecutivelyError[P: EventPayload](BaseAssertionError[P]):
     """Expected events were not published consecutively."""
 
     @override
@@ -93,7 +90,7 @@ class NotPublishedConsecutivelyError(BaseAssertionError):
         return "Expected events were not published consecutively"
 
 
-class NotPublishedError(BaseAssertionError):
+class NotPublishedError[P: EventPayload](BaseAssertionError[P]):
     """Some expected items were not published."""
 
     def __init__(
@@ -116,7 +113,7 @@ class NotPublishedError(BaseAssertionError):
         )
 
 
-class PublishedList(list[P]):
+class PublishedList[P: EventPayload](list[P]):
     """A list of event payload models with assertion helpers.
 
     All assertion helpers take lists of dicts as expected items and use the

--- a/safir/src/safir/pydantic/_camel.py
+++ b/safir/src/safir/pydantic/_camel.py
@@ -3,13 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, ParamSpec, TypeVar, override
+from typing import Any, override
 
 from pydantic import BaseModel, ConfigDict
-
-P = ParamSpec("P")
-T = TypeVar("T")
-
 
 __all__ = [
     "CamelCaseModel",
@@ -56,7 +52,7 @@ def to_camel_case(string: str) -> str:
     return components[0] + "".join(c.title() for c in components[1:])
 
 
-def _copy_type(
+def _copy_type[**P, T](
     parent: Callable[P, T],
 ) -> Callable[[Callable[..., T]], Callable[P, T]]:
     """Copy the type of a parent method.

--- a/safir/src/safir/pydantic/_validators.py
+++ b/safir/src/safir/pydantic/_validators.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any, TypeVar
+from typing import Any
 
 from pydantic import BaseModel
 
 from safir.datetime import parse_isodatetime
-
-T = TypeVar("T")
 
 __all__ = [
     "normalize_datetime",
@@ -188,7 +186,7 @@ def validate_exactly_one_of(
     else:
         options = ", ".join(settings[:-1]) + ", and " + settings[-1]
 
-    def validator(model: T) -> T:
+    def validator[T: BaseModel](model: T) -> T:
         seen = False
         for setting in settings:
             if getattr(model, setting, None) is not None:

--- a/safir/src/safir/redis/_storage.py
+++ b/safir/src/safir/redis/_storage.py
@@ -1,9 +1,7 @@
 """Store Pydantic models in Redis with optional encryption."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator
-from typing import Generic, TypeVar, override
+from typing import override
 
 try:
     import redis.asyncio as redis
@@ -56,11 +54,7 @@ class DeserializeError(SlackException):
         return message
 
 
-#: Type variable of Pydantic object being stored in `PydanticRedisStorage`.
-S = TypeVar("S", bound="BaseModel")
-
-
-class PydanticRedisStorage(Generic[S]):
+class PydanticRedisStorage[S: BaseModel]:
     """JSON-serialized encrypted storage in Redis.
 
     Parameters
@@ -216,7 +210,7 @@ class PydanticRedisStorage(Generic[S]):
         return self._datatype.model_validate_json(data.decode())
 
 
-class EncryptedPydanticRedisStorage(PydanticRedisStorage[S]):
+class EncryptedPydanticRedisStorage[S: BaseModel](PydanticRedisStorage[S]):
     """A Pydantic-based Redis store that encrypts data.
 
     Parameters


### PR DESCRIPTION
Use the new syntax added in Python 3.12 for generics. This results in better typing in mypy, which required a few added casts because the typing of metrics publishers is dynamic and somewhat strange.

Sphinx unfortunately has bugs generating documentation for generics when `from __future__ import annotations` is present, so remove that line from several modules so that the documentation will generate properly.

autodoc_pydantic is unfortunately very buggy when used with `Annotated`, which required several additional ignore rules and probably results in poor documentation for some Pydantic models.