### PR TITLE
DM-49036: Use type instead of TypeAlias

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -17,10 +17,12 @@ nitpick_ignore_regex = [
     ['py:.*', 'pydantic.*'],
     ['py:.*', 'respx.*'],
     ['py:.*', 'starlette.*'],
+    # Sphinx bug handling the type keyword
+    ['py:.*', '.*\.TypeAliasType'],
     # autodoc_pydantic does not handle validators or Annotated correctly.
-    ["py:obj", ".*\\.all fields"],
-    ["py:obj", "lambda.*"],
-    ["py:obj", "ExecutionPhase.*"]
+    ['py:obj', '.*\.all fields'],
+    ['py:obj', 'lambda.*'],
+    ['py:obj', 'ExecutionPhase.*']
 ]
 nitpick_ignore = [
     # These don't appear to have documentation but show up in the inheritance
@@ -28,8 +30,8 @@ nitpick_ignore = [
     ["py:class", "unittest.mock.Base"],
     ["py:class", "unittest.mock.CallableMixin"],
     # autodoc_pydantic generates some spurious links that can't be resolved.
-    ['py:class', 'unittest.mock.Base'],
-    ['py:class', 'unittest.mock.CallableMixin'],
+    ["py:class", "unittest.mock.Base"],
+    ["py:class", "unittest.mock.CallableMixin"],
     ["py:obj", "ComputedFieldInfo"],
     ["py:class", "lambda"],
     ["py:obj", "typing.P"],
@@ -38,8 +40,7 @@ nitpick_ignore = [
     ["py:class", "arq.typing.StartupShutdown"],
     ["py:class", "arq.typing.WorkerCoroutine"],
     ["py:class", "arq.worker.Function"],
-    # Including the documentation for these generates the pages but doesn't
-    # include them in the table of contents, so for now they're excluded.
+    # Sphinx apparently cannot handle type aliases.
     ["py:obj", "safir.pydantic.EnvAsyncPostgresDsn"],
     ["py:obj", "safir.pydantic.EnvRedisDsn"],
     ["py:obj", "safir.pydantic.HumanTimedelta"],

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Annotated, TypeAlias, override
+from typing import Annotated, override
 
 import structlog
 from aiokafka.admin.client import AIOKafkaAdminClient
@@ -251,7 +251,7 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
         )
 
 
-MetricsConfiguration: TypeAlias = (
+type MetricsConfiguration = (
     MockMetricsConfiguration
     | DisabledMetricsConfiguration
     | KafkaMetricsConfiguration

--- a/safir/src/safir/metrics/_testing.py
+++ b/safir/src/safir/metrics/_testing.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from pprint import pformat
-from typing import Any, TypeAlias, override
+from typing import Any, override
 from unittest.mock import ANY as MOCK_ANY
 
 from ._models import EventPayload
@@ -21,7 +21,7 @@ __all__ = [
 ANY = MOCK_ANY
 """An object that compares equal to anything, reexported from unittest.mock."""
 
-ModelDumpList: TypeAlias = list[dict[str, Any]]
+type ModelDumpList = list[dict[str, Any]]
 """Type alias for a list of dumped Pydantic models."""
 
 

--- a/safir/src/safir/pydantic/_types.py
+++ b/safir/src/safir/pydantic/_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta
-from typing import Annotated, TypeAlias
+from typing import Annotated
 
 from pydantic import (
     AfterValidator,
@@ -52,7 +52,7 @@ def _validate_env_async_postgres_dsn(v: Url) -> Url:
         return v
 
 
-EnvAsyncPostgresDsn: TypeAlias = Annotated[
+type EnvAsyncPostgresDsn = Annotated[
     Url,
     UrlConstraints(
         host_required=True,
@@ -92,7 +92,7 @@ def _validate_env_redis_dsn(v: Url) -> Url:
         return v
 
 
-EnvRedisDsn: TypeAlias = Annotated[
+type EnvRedisDsn = Annotated[
     Url,
     UrlConstraints(
         allowed_schemes=["redis"],
@@ -118,7 +118,7 @@ def _validate_human_timedelta(v: str | float | timedelta) -> float | timedelta:
         return parse_timedelta(v)
 
 
-HumanTimedelta: TypeAlias = Annotated[
+type HumanTimedelta = Annotated[
     timedelta,
     BeforeValidator(_validate_human_timedelta),
     PlainSerializer(
@@ -144,7 +144,7 @@ valid strings are ``8d`` (8 days), ``4h 3minutes`` (four hours and three
 minutes), and ``5w4d`` (five weeks and four days).
 """
 
-SecondsTimedelta: TypeAlias = Annotated[
+type SecondsTimedelta = Annotated[
     timedelta,
     BeforeValidator(lambda v: v if not isinstance(v, str) else float(v)),
     PlainSerializer(
@@ -159,9 +159,7 @@ built-in Pydantic handling of `~datetime.timedelta`, an integer number of
 seconds as a string is accepted, and ISO 8601 durations are not supported.
 """
 
-UtcDatetime: TypeAlias = Annotated[
-    datetime, AfterValidator(normalize_datetime)
-]
+type UtcDatetime = Annotated[datetime, AfterValidator(normalize_datetime)]
 """Coerce a `~datetime.datetime` to UTC.
 
 Accepts as input all of the normal Pydantic representations of a
@@ -169,7 +167,7 @@ Accepts as input all of the normal Pydantic representations of a
 UTC.
 """
 
-IvoaIsoDatetime: TypeAlias = Annotated[
+type IvoaIsoDatetime = Annotated[
     datetime,
     BeforeValidator(normalize_isodatetime),
     PlainSerializer(isodatetime, return_type=str, when_used="json"),

--- a/safir/src/safir/uws/_config.py
+++ b/safir/src/safir/uws/_config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TypeAlias
 
 from arq.connections import RedisSettings
 from pydantic import Field, HttpUrl, SecretStr
@@ -17,10 +16,10 @@ from safir.pydantic import EnvRedisDsn, HumanTimedelta, SecondsTimedelta
 
 from ._models import Job, ParametersModel
 
-DestructionValidator: TypeAlias = Callable[[datetime, Job], datetime]
+type DestructionValidator = Callable[[datetime, Job], datetime]
 """Type for a validator for a new destruction time."""
 
-ExecutionDurationValidator: TypeAlias = Callable[
+type ExecutionDurationValidator = Callable[
     [timedelta | None, Job], timedelta | None
 ]
 """Type for a validator for a new execution duration."""


### PR DESCRIPTION
Declare type aliases with the new `type` keyword instead of using the `TypeAlias` type. Sphinx unfortunately cannot currently cope with these, so more exclusions were required.