### PR TITLE
DM-49117: Add `number` to GitHubCheckRunPrInfoModel

### DIFF
--- a/changelog.d/20250224_140058_danfuchs_update_github_pr_model.md
+++ b/changelog.d/20250224_140058_danfuchs_update_github_pr_model.md
@@ -1,0 +1,3 @@
+### New features
+
+- Added `number` field to `GitHubCheckRunPrInfoModel` to capture the pull request number in GitHub check events

--- a/safir/src/safir/github/models.py
+++ b/safir/src/safir/github/models.py
@@ -381,6 +381,10 @@ class GitHubCheckRunPrInfoModel(BaseModel):
 
     url: HttpUrl = Field(description="GitHub API URL for this pull request.")
 
+    number: int = Field(
+        description="The number that identifies the pull request."
+    )
+
 
 class GitHubCheckRunModel(BaseModel):
     """A Pydantic model for the "check_run" field in a check_run webhook


### PR DESCRIPTION
The Mobu CI integration wants to run against all of the files in a PR.
It is planning on using the [list pull request files](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files) API endpoint, which takes a PR number.
We get this PR number back in the check run info response.