### PR TITLE
DM-49503: Update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/safir/src/safir/metadata/_retrieve.py
+++ b/safir/src/safir/metadata/_retrieve.py
@@ -59,7 +59,7 @@ def get_metadata(*, package_name: str, application_name: str) -> Metadata:
     project_urls, Source code
         Used as the ``respository_url``.
     """
-    pkg_metadata = cast(Message, metadata(package_name))
+    pkg_metadata = cast("Message", metadata(package_name))
 
     # Newer packages that use pyproject.toml only do not use the Home-page
     # field (setuptools in pyproject.toml mode does not support it) and use

--- a/safir/src/safir/metrics/_event_manager.py
+++ b/safir/src/safir/metrics/_event_manager.py
@@ -147,7 +147,7 @@ class KafkaEventPublisher[P: EventPayload](EventPublisher[P]):
     async def publish(self, payload: P) -> EventMetadata:
         event = self.construct_event(payload)
         await self._manager.publish(event, self._publisher, self._schema_info)
-        return cast(EventMetadata, event)
+        return cast("EventMetadata", event)
 
 
 class NoopEventPublisher[P: EventPayload](EventPublisher[P]):
@@ -173,7 +173,7 @@ class NoopEventPublisher[P: EventPayload](EventPublisher[P]):
         self._logger.debug(
             "Would have published event", metrics_event=event.model_dump()
         )
-        return cast(EventMetadata, event)
+        return cast("EventMetadata", event)
 
 
 class MockEventPublisher[P: EventPayload](NoopEventPublisher[P]):
@@ -319,7 +319,7 @@ class EventManager(metaclass=ABCMeta):
 
         # Construct the event model.
         model = cast(
-            type[P],
+            "type[P]",
             create_model(
                 "EventModel",
                 __base__=(payload_model, EventMetadata, MetaBase),

--- a/safir/tests/metadata_test.py
+++ b/safir/tests/metadata_test.py
@@ -13,7 +13,7 @@ from safir.metadata import get_metadata, get_project_url
 
 @pytest.fixture(scope="session")
 def safir_metadata() -> Message:
-    return cast(Message, metadata("safir"))
+    return cast("Message", metadata("safir"))
 
 
 def test_get_project_url(safir_metadata: Message) -> None:

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -81,7 +81,7 @@ async def assert_from_kafka(
     serializer = AsyncAvroMessageSerializer(schema_registry)
     deserialized_dict = await serializer.decode_message(message.value)
     assert deserialized_dict is not None
-    event_class = cast(type[AvroBaseModel], event._event_class)
+    event_class = cast("type[AvroBaseModel]", event._event_class)
     deserialized = event_class(**deserialized_dict)
 
     assert isinstance(deserialized, EventMetadata)

--- a/safir/tests/metrics/mock_publisher_test.py
+++ b/safir/tests/metrics/mock_publisher_test.py
@@ -47,7 +47,7 @@ async def publish() -> PublishedList:
 
     await manager.aclose()
 
-    return cast(MockEventPublisher, pub).published
+    return cast("MockEventPublisher", pub).published
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix the suggestions offered by the latest Ruff. Switch the logging inside safir.testing.uvicorn to use structlog to silence warnings about using the top-level logging functions, and take the logger as a parameter just for consistency with other Safir APIs. It's unlikely any caller will use this capability.