### PR TITLE
DM-49735: Update license metadata and PyPI publish action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,23 +109,20 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Test building and publishing safir
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir"
 
       - name: Test building and publishing safir-arq
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir-arq"
 
       - name: Test building and publishing safir-logging
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir-logging"
 
@@ -147,17 +144,14 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: lsst-sqre/build-and-publish-to-pypi@v2
+      - uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           working-directory: "safir"
 
-      - uses: lsst-sqre/build-and-publish-to-pypi@v2
+      - uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           working-directory: "safir-arq"
 
-      - uses: lsst-sqre/build-and-publish-to-pypi@v2
+      - uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           working-directory: "safir-logging"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -85,23 +85,20 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Test package build of safir
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir"
 
       - name: Test package build of safir-arq
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir-arq"
 
       - name: Test package build of safir-logging
-        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           upload: false
           working-directory: "safir-logging"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 2020-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/safir-arq/pyproject.toml
+++ b/safir-arq/pyproject.toml
@@ -2,8 +2,9 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "safir-arq"
 description = "arq support for the Rubin Observatory SQuaRE framework, Safir."
-license = {file = "LICENSE"}
-readme= "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+readme = "README.md"
 keywords = [
     "rubin",
     "lsst",
@@ -11,7 +12,6 @@ keywords = [
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/safir-logging/pyproject.toml
+++ b/safir-logging/pyproject.toml
@@ -2,8 +2,9 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "safir-logging"
 description = "Logging for the Rubin Observatory SQuaRE framework, Safir."
-license = {file = "LICENSE"}
-readme= "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+readme = "README.md"
 keywords = [
     "rubin",
     "lsst",
@@ -11,7 +12,6 @@ keywords = [
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -2,8 +2,9 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "safir"
 description = "The Rubin Observatory SQuaRE framework for FastAPI services."
-license = {file = "LICENSE"}
-readme= "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+readme = "README.md"
 keywords = [
     "rubin",
     "lsst",
@@ -11,7 +12,6 @@ keywords = [
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -79,6 +79,8 @@ class BaseMetricsConfiguration(BaseSettings, ABC):
     clients.
     """
 
+    model_config = SettingsConfigDict(populate_by_name=True)
+
     application: str = Field(
         ...,
         title="Application name",

--- a/safir/tests/conftest.py
+++ b/safir/tests/conftest.py
@@ -208,7 +208,7 @@ def schema_manager_settings(
     )
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 def schema_manager(
     schema_manager_settings: SchemaManagerSettings,
 ) -> PydanticSchemaManager:


### PR DESCRIPTION
Use v3 of lsst-sqre/build-and-publish-to-pypi, which uses uv to build and publish the package instead of the PyPA build tool and twine. Update the license metadata in the packages to follow PEP 639.