### PR TITLE
DM-50095: Add asyncmy and connect_args support for databases

### DIFF
--- a/changelog.d/20250411_171300_rra_DM_50095.md
+++ b/changelog.d/20250411_171300_rra_DM_50095.md
@@ -1,0 +1,4 @@
+### New features
+
+- `create_async_engine` now rewrites URLs with a scheme of `mysql` to use `mysql+asyncmy`, similar to the existing rewrite of `postgresql` to `postgresql+asyncpg`.
+- Add an optional `connect_args` parameter to `create_async_engine` that can be used to pass parameters directly to the underlying database driver. This may be used to, for example, configure TLS settings.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,5 +1,6 @@
 .. _Alembic: https://alembic.sqlalchemy.org/en/latest/
 .. _arq: https://arq-docs.helpmanual.io
+.. _asyncmy: https://github.com/long2ice/asyncmy
 .. _asyncpg: https://magicstack.github.io/asyncpg/current/
 .. _Click: https://click.palletsprojects.com/en/stable/
 .. _cryptography: https://cryptography.io/en/latest/

--- a/docs/user-guide/database/index.rst
+++ b/docs/user-guide/database/index.rst
@@ -7,10 +7,12 @@ Safir-based applications that use FastAPI can also use the Safir-provided FastAP
 The Safir database support is based on `SQLAlchemy`_ and assumes use of PostgreSQL (possibly via `Cloud SQL <https://cloud.google.com/sql>`__) as the underlying database.
 
 Safir is an asyncio framework and requires using SQLAlchemy's asyncio API.
-Safir uses the `asyncpg`_ PostgreSQL database driver.
+Safir uses the asyncpg_ PostgreSQL database driver by default for PostgreSQL databases and the asyncmy_ MySQL database driver by default for MySQL databases.
+PostgreSQL is strongly preferred and should be used where possible.
 
 Database support in Safir is optional.
 To use it, depend on ``safir[db]`` in your pip requirements.
+When using Safir with MySQL, you will also need to depend on ``asyncmy``.
 
 Also see :ref:`pydantic-dsns` for Pydantic types that help with configuring the PostgreSQL DSN.
 


### PR DESCRIPTION
The Qserv Kafka bridge needs to speak MySQL rather than PostgreSQL to the Qserv frontend. Add support for rewriting `mysql` DSNs to `mysql+asyncmy`, similar to the existing rewrite of `postgresql` DSNs, to `create_async_engine`, and add support for a `connect_args` parameter to pass arguments to the underlying database driver. The latter is needed to configure TLS parameters with asyncmy.