### PR TITLE
DM-50527: Allow configuration of database pool size

### DIFF
--- a/changelog.d/20250505_134035_rra_DM_50527.md
+++ b/changelog.d/20250505_134035_rra_DM_50527.md
@@ -1,0 +1,4 @@
+### New features
+
+- Add additional parameters `max_overflow`, `pool_size`, and `pool_timeout` to `safir.database.create_database_engine`. These are passed to the SQLAlchemy `create_async_engine` function and can be used to tweak pool behavior.
+- Add additional parameters `connect_args`, `max_overflow`, `pool_size`, and `pool_timeout` to the `initialize` method of the database session FastAPI dependency. These parameters are passed to `create_database_engine` when creating the underlying engine.

--- a/docs/user-guide/database/dependency.rst
+++ b/docs/user-guide/database/dependency.rst
@@ -34,6 +34,8 @@ You must also close the dependency during application shutdown.
 
    app = FastAPI(lifespan=lifespan)
 
+`~safir.dependencies.db_session.DatabaseSessionDependency.initialize` takes the same optional parameters as `~safir.database.create_database_engine`.
+
 As with some of the examples above, this assumes the application has a ``config`` object with the application settings, including the database URL and password.
 
 Using the dependency

--- a/docs/user-guide/database/session.rst
+++ b/docs/user-guide/database/session.rst
@@ -30,6 +30,8 @@ To get a new async database connection, use code like the following:
 Creating the engine is separate from creating the session so that the engine can be disposed of properly.
 This ensures the connection pool is closed.
 
+The ``connect_args``, ``max_overflow``, ``pool_size``, and ``pool_timeout`` parameters to `~safir.database.create_database_engine` have the same meaning as the corresponding arguments to `sqlalchemy.create_engine`.
+
 .. _probing-db-connection:
 
 Probing the database connection

--- a/safir/src/safir/database/_connection.py
+++ b/safir/src/safir/database/_connection.py
@@ -82,8 +82,11 @@ def create_database_engine(
     url: str | Url,
     password: str | SecretStr | None,
     *,
-    isolation_level: str | None = None,
     connect_args: dict[str, Any] | None = None,
+    isolation_level: str | None = None,
+    max_overflow: int | None = None,
+    pool_size: int | None = None,
+    pool_timeout: float | None = None,
 ) -> AsyncEngine:
     """Create a new async database engine.
 
@@ -93,12 +96,19 @@ def create_database_engine(
         Database connection URL, not including the password.
     password
         Database connection password.
-    isolation_level
-        If specified, sets a non-default isolation level for the database
-        engine.
     connect_args
         Additional connection arguments to pass directly to the underlying
         database driver.
+    isolation_level
+        If specified, sets a non-default isolation level for the database
+        engine.
+    max_overflow
+        Maximum number of connections over the pool size for surge traffic.
+    pool_size
+        Connection pool size.
+    pool_timeout
+        How long to wait for a connection from the connection pool before
+        giving up.
 
     Returns
     -------
@@ -113,10 +123,16 @@ def create_database_engine(
     """
     url = build_database_url(url, password)
     kwargs: dict[str, Any] = {}
-    if isolation_level:
-        kwargs["isolation_level"] = isolation_level
     if connect_args:
         kwargs["connect_args"] = connect_args
+    if isolation_level:
+        kwargs["isolation_level"] = isolation_level
+    if max_overflow is not None:
+        kwargs["max_overflow"] = max_overflow
+    if pool_size is not None:
+        kwargs["pool_size"] = pool_size
+    if pool_timeout is not None:
+        kwargs["pool_timeout"] = pool_timeout
     return create_async_engine(url, **kwargs)
 
 


### PR DESCRIPTION
Pass the `max_overflow`, `pool_size`, and `pool_timeout` arguments down to the engine creation. Add all of the `create_database_engine` to the `initialize` method of `DatabaseSessionDependency` as well, and note them in the documentation.

This change still takes the approach of declaring each parameter separately rather than passing all unknown parameters through to SQLAlchemy. This results in better type checking at the cost of having to change Safir for each new supported parameter. The code is constructed to not pass a parameter, even with a value of `None`, if that parameter was not set, mostly out of paranoia that some engine parameter may give a special meaning to `None`.