### PR TITLE
Update for Click 8.2.0

### DIFF
--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -5,10 +5,7 @@ description = "The Rubin Observatory SQuaRE framework for FastAPI services."
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
-keywords = [
-    "rubin",
-    "lsst",
-]
+keywords = ["rubin", "lsst"]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -24,7 +21,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "aiokafka>=0.11,<1",
-    "click<9",
+    "click>=8.2.0,<9",
     "cryptography<45",
     "dataclasses-avroschema>=0.65.7,<1",
     "fastapi>=0.100,<1",

--- a/safir/src/safir/click/_help.py
+++ b/safir/src/safir/click/_help.py
@@ -75,9 +75,9 @@ def display_help(
 
     # Subtopic handling. This requires some care with typing, since the
     # commands attribute (although present) is not documented, and the
-    # get_command method is only available on MultiCommands.
+    # get_command method is only available on Groups.
     group = main.commands[topic]
-    if isinstance(group, click.MultiCommand):
+    if isinstance(group, click.Group):
         command = group.get_command(ctx, subtopic)
         if command:
             ctx.info_name = f"{topic} {subtopic}"


### PR DESCRIPTION
Use `click.Group` instead of `click.MultiCommand` and update the minimum Click version to 8.2.0 to avoid needing to worry about backward-compatibility.