### PR TITLE
DM-50964: Force arq 0.26 or later

### DIFF
--- a/safir-arq/pyproject.toml
+++ b/safir-arq/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "arq>=0.23,<1",
+    "arq>=0.26,<1",
     "pydantic>2,<3",
     "pydantic-core",
     "structlog>=21.2.0",


### PR DESCRIPTION
Force the version of arq to 0.26 or later, since that appears to be when arq added a maximum version restriction on redis. Otherwise, uv is willing to adopt a dependency resolution that downgrades arq to 0.25 to install redis 6.1.0, a combination that probably will not work correctly due to changes in the redis API.