### PR TITLE
DM-50964: Support serialization options for Redis storage

### DIFF
--- a/changelog.d/20250521_132914_rra_DM_50964.md
+++ b/changelog.d/20250521_132914_rra_DM_50964.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support the standard Pydantic `exclude_unset`, `exclude_defaults`, and `exclude_none` arguments to `PydanticRedisStorage.store`.

--- a/docs/user-guide/pydantic-redis.rst
+++ b/docs/user-guide/pydantic-redis.rst
@@ -136,3 +136,15 @@ Each `~safir.redis.PydanticRedisStorage` instance works with a specific Pydantic
        redis=redis_client,
        key_prefix="customer:",
    )
+
+Reducing the size of serialized objects
+=======================================
+
+By default, the Pydantic model is serialized to JSON for storage using the default Pydantic serialization, which includes all defined fields.
+This is normally the best serialization to use since it is the most robust against future changes, such as changing default values for fields.
+
+Sometimes, though, you may prefer to reduce the size of the serialized models in exchange for having to be more careful about model changes.
+The `~safir.redis.PydanticRedisStorage.store` method of `~safir.redis.PydanticRedisStorage` and `~safir.redis.EncryptedPydanticRedisStorage` support the Pydantic options ``exclude_unset``, ``exclude_defaults``, and ``exclude_none`` to change the default serialization.
+These options have the same meaning as the corresponding options to Pydantic's ``model_dump_json`` method.
+
+See `the Pydantic documentation <https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_dump_json>`__ for more details.


### PR DESCRIPTION
In the `store` method of `PydanticRedisStorage` and `EncryptedPydanticRedisStorage`, support some of the Pydantic serialization options so that applications can reduce the size of serialized objects with large numbers of optional fields. Document that normally these flags should not be used because the default serialization is more future-proof.

This support is desired to reduce the size of query objects stored by the Qserv Kafka bridge with wide returns, since the optional fields for the per-column schema definition otherwise can consume over 100KB of space in the serialized object.