### PR TITLE
Adjust for changes in dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ nox.options.reuse_existing_virtualenvs = True
 PIP_DEPENDENCIES = (
     ("-e", "./safir-arq"),
     ("-e", "./safir-logging"),
-    ("-e", "./safir[arq,db,dev,gcs,kubernetes,redis,uws]"),
+    ("-e", "./safir[arq,db,dev,gcs,kubernetes,redis,testcontainers,uws]"),
 )
 
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -49,6 +49,7 @@ db = [
     "sqlalchemy[asyncio]>=2.0.0,<3",
 ]
 dev = [
+    "alembic[tz]>=1.16",
     "asgi-lifespan",
     "coverage[toml]",
     "fastapi>=0.93.0",

--- a/safir/tests/data/database/v1/alembic.ini
+++ b/safir/tests/data/database/v1/alembic.ini
@@ -3,9 +3,9 @@
 [alembic]
 script_location = %(here)s/alembic
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+path_separator = os
 prepend_sys_path = .
 timezone = UTC
-version_path_separator = os
 
 [post_write_hooks]
 hooks = ruff ruff_format

--- a/safir/tests/data/database/v2/alembic.ini
+++ b/safir/tests/data/database/v2/alembic.ini
@@ -3,9 +3,9 @@
 [alembic]
 script_location = %(here)s/alembic
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+path_separator = os
 prepend_sys_path = .
 timezone = UTC
-version_path_separator = os
 
 [post_write_hooks]
 hooks = ruff ruff_format

--- a/safir/tests/database_test.py
+++ b/safir/tests/database_test.py
@@ -255,8 +255,8 @@ def test_alembic(
     database_url: str,
     database_password: str,
     monkeypatch: pytest.MonkeyPatch,
-    event_loop: asyncio.AbstractEventLoop,
 ) -> None:
+    event_loop = asyncio.get_event_loop()
     config.database_url = Url(database_url)
     config.database_password = SecretStr(database_password)
     config_path = (

--- a/safir/tests/database_test.py
+++ b/safir/tests/database_test.py
@@ -256,7 +256,7 @@ def test_alembic(
     database_password: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event_loop = asyncio.get_event_loop()
+    event_loop = asyncio.new_event_loop()
     config.database_url = Url(database_url)
     config.database_password = SecretStr(database_password)
     config_path = (


### PR DESCRIPTION
Fix periodic test failures and warnings with new versions of dependencies, as follows:

- pytest-asyncio 1.0.0 has removed the `event_loop` fixture. Adjust the test suite accordingly.
- Alembic 1.16.0 has added `path_separator`, replacing `version_path_separator`, and warns if it is not present in the configuration. Update the test configuration accordingly.