### PR TITLE
Update sample Alembic configuration

### DIFF
--- a/docs/user-guide/database/schema.rst
+++ b/docs/user-guide/database/schema.rst
@@ -43,9 +43,9 @@ Replace :file:`alembic.ini` with the following:
    [alembic]
    script_location = %(here)s/alembic
    file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+   path_separator = os
    prepend_sys_path = .
    timezone = UTC
-   version_path_separator = os
 
    [post_write_hooks]
    hooks = ruff ruff_format


### PR DESCRIPTION
Use the new `path_separator` configuration setting instead of the deprecated `version_path_separator` in the sample Alembic configuration.