### PR TITLE
Fix issues arising from dependency updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -15,6 +15,7 @@ nitpick_ignore_regex = [
     ['py:.*', 'kubernetes_asyncio.*'],
     ['py:.*', 'httpx.*'],
     ['py:.*', 'pydantic.*'],
+    ['py:.*', 'redis.*'],
     ['py:.*', 'respx.*'],
     ['py:.*', 'starlette.*'],
     # Sphinx bug handling the type keyword
@@ -75,7 +76,6 @@ cryptography = "https://cryptography.io/en/latest"
 gidgethub = "https://gidgethub.readthedocs.io/en/latest"
 pytest = "https://docs.pytest.org/en/stable"
 python = "https://docs.python.org/3"
-redis = "https://redis-py.readthedocs.io/en/stable"
 schema_registry = "https://marcosschroh.github.io/python-schema-registry-client"
 sentry_sdk = "https://getsentry.github.io/sentry-python/"
 structlog = "https://www.structlog.org/en/stable"

--- a/safir-arq/src/safir/arq/_models.py
+++ b/safir-arq/src/safir/arq/_models.py
@@ -32,34 +32,7 @@ class ArqMode(StrEnum):
 
 @dataclass
 class JobMetadata:
-    """Information about a queued job.
-
-    Attributes
-    ----------
-    id
-        The `arq.jobs.Job` identifier
-    name
-        The task name.
-    args
-        The positional arguments to the task function.
-    kwargs
-        The keyword arguments to the task function.
-    enqueue_time
-        Time when the job was added to the queue.
-    status
-        Status of the job.
-
-        States are defined by the `arq.jobs.JobStatus` enumeration:
-
-        - ``deferred`` (in queue, but waiting a predetermined time to become
-          ready to run)
-        - ``queued`` (queued to run)
-        - ``in_progress`` (actively being run by a worker)
-        - ``complete`` (result is available)
-        - ``not_found`` (the job cannot be found)
-    queue_name
-        Name of the queue this job belongs to.
-    """
+    """Information about a queued job."""
 
     id: str
     """The `~arq.jobs.Job` identifier."""
@@ -124,41 +97,7 @@ class JobMetadata:
 
 @dataclass
 class JobResult(JobMetadata):
-    """The full result of a job, as well as its metadata.
-
-    Attributes
-    ----------
-    id
-        The `~arq.jobs.Job` identifier
-    name
-        The task name.
-    args
-        The positional arguments to the task function.
-    kwargs
-        The keyword arguments to the task function.
-    enqueue_time
-        Time when the job was added to the queue.
-    status
-        Status of the job.
-
-        States are defined by the `arq.jobs.JobStatus` enumeration:
-
-        - ``deferred`` (in queue, but waiting a predetermined time to become
-          ready to run)
-        - ``queued`` (queued to run)
-        - ``in_progress`` (actively being run by a worker)
-        - ``complete`` (result is available)
-        - ``not_found`` (the job cannot be found)
-    start_time
-        Time when the job started.
-    finish_time
-        Time when the job finished.
-    success
-        `True` if the job returned without an exception, `False` if an
-        exception was raised.
-    result
-        The job's result.
-    """
+    """The full result of a job, as well as its metadata."""
 
     start_time: datetime
     """Time when the job started."""

--- a/safir/src/safir/metrics/_testing.py
+++ b/safir/src/safir/metrics/_testing.py
@@ -34,6 +34,8 @@ class _NotNone:
     def __repr__(self) -> str:
         return "<NOT NONE>"
 
+    __hash__ = object.__hash__
+
 
 NOT_NONE = _NotNone()
 """An object to indicate that a value can be anything except None."""

--- a/safir/src/safir/sentry/_helpers.py
+++ b/safir/src/safir/sentry/_helpers.py
@@ -36,7 +36,9 @@ def fingerprint_env_handler(event: Event, _: Hint) -> Event:
 
     https://github.com/getsentry/sentry/issues/64354
     """
-    env = event.get("environment", "no environment")
+    env = event.get("environment")
+    if env is None:
+        env = "no environment"
     fingerprint = event.get("fingerprint", [])
     event["fingerprint"] = [
         "{{ default }}",

--- a/safir/src/safir/uws/_config.py
+++ b/safir/src/safir/uws/_config.py
@@ -77,10 +77,10 @@ class UWSConfig:
     job_summary_type: type[JobSummary]
     """Type representing the parameter-qualified job summary type.
 
-    Must be set to `~vo_models.uws.JobSummary` qualified with the appropriate
-    subclass of `~vo_models.uws.Parameters`. This is necessary to work around
-    limitations in pydantic-xml, which require the types to be known at class
-    instantiation time.
+    Must be set to `~vo_models.uws.models.JobSummary` qualified with the
+    appropriate subclass of `~vo_models.uws.models.Parameters`. This is
+    necessary to work around limitations in pydantic-xml, which require the
+    types to be known at class instantiation time.
     """
 
     lifetime: timedelta

--- a/safir/tests/uws/job_api_test.py
+++ b/safir/tests/uws/job_api_test.py
@@ -638,7 +638,7 @@ async def test_validators(
     assert r.headers["Location"] == "https://example.com/test/jobs/1"
     r = await client.get("/test/jobs/1/destruction")
     assert r.status_code == 200
-    seen = datetime.fromisoformat(r.text[:-1] + "+00:00")
+    seen = datetime.fromisoformat(r.text)
     assert seen >= expected - timedelta(seconds=5)
     assert seen <= expected + timedelta(seconds=5)
 


### PR DESCRIPTION
Update pre-commit dependencies and fix several issues uncovered by testing with new dependencies.

For Ruff, adjust the logic around `None` values in Sentry event fingerprints, simplify code in a test to pass Ruff 0.12, and add a missing `__hash__` setting for `NOT_NONE`.

For Sphinx, drop intersphinx for Redis since it's no longer maintained and add Redis symbols to the ignore list. Remove duplicate dataclass attribute documentation since Sphinx now handles this correctly by default. Fix the names of vo-models symbols to match their exposed intersphinx names.