### PR TITLE
Get proper version numbers in periodic CI

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -55,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
 
       - name: Install Graphviz
         run: sudo apt-get install graphviz


### PR DESCRIPTION
Get the full version history so that setuptools-scm can get proper version numbers in the periodic CI jobs. Otherwise, it will install the last released safir-arq package.