### PR TITLE
DM-48229: App metrics application resiliency

### DIFF
--- a/changelog.d/20250625_132809_danfuchs_HEAD.md
+++ b/changelog.d/20250625_132809_danfuchs_HEAD.md
@@ -1,0 +1,14 @@
+### New features
+
+#### App Metrics Application Resiliency
+
+If the underlying app metrics infrastructure is degraded, like if Kafka or the Schema Registry are not available, the Safir app metrics code now tries very hard to not crash or your instrumented application.
+
+Instead of of raising exceptions, it will log error-level messages and put itself into an error state. Once in this error state, it will not even try to interact with any underlying infrastructure, which means it will not even try to send metrics for a configurable amount of time.
+It will instead only log error messages.
+
+If this happens during initialization, you will have to restart your app after the underlying infrastructure is fixed to start sending metrics again. if This happens after successful initialization, the app may start sending metrics again by itself after the underlying infrastructure is fixed.
+
+There are two new config options:
+* The `raise_on_error` config option to `KafkaMetricsConfiguration` can be set to `False` to raise all exceptions to the instrumented app instead of swallowing them and logging errors.
+* The `backoff_interval` config option to `KafkaMetricsConfiguration` sets the amount of time to wait before trying to send metrics again if an error state is entered after initialization.

--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -30,6 +30,9 @@ The ``raise_on_error`` config option to ``KafkaMetricsConfiguration`` can be set
 
 The ``backoff_interval`` config option to ``KafkaMetricsConfiguration`` sets the amount of time to wait before trying to send metrics again if an error state is entered after initialization.
 
+While in an error state, only one error message per attempted operation will be logged during a ``backoff_interval``, even if it is attempted multiple times.
+For example, if an event manager gets into an error state, ``backoff_interval`` is set to 5 minutes, and 50 events are published in 1 minute, there will only be one error message logged.
+
 Metrics vs. telemetry
 =====================
 

--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -9,6 +9,27 @@ Using these helpers, your can instrument your app to push custom events to a Sas
 .. _Chronograf: https://www.influxdata.com/time-series-platform/chronograf
 .. _graph them: https://sasquatch.lsst.io/user-guide/dashboards.html
 
+Application Resiliency
+======================
+
+.. warning::
+
+   The app metrics functionality prioritizes the resiliency of your instrumented app over the reliability of sending app metrics.
+   If your app metrics instrumentation gets into an error state during initialization, you will have to restart your app to start sending metrics again, even if the underlying infrastructure comes back up.
+
+If the underlying app metrics infrastructure is degraded, like if Kafka or the Schema Registry are not available, the Safir app metrics code tries very hard to not crash or your instrumented application.
+
+Instead of of raising exceptions, it will log error-level messages and put itself into an error state.
+Once in this error state, it will not even try to interact with any underlying infrastructure, which means it will not even try to send metrics for a configurable amount of time.
+It will instead only log error messages.
+
+If this happens during initialization, you will have to restart your app after the underlying infrastructure is fixed to start sending metrics again.
+If this happens after successful initialization, the app may start sending metrics again by itself after the underlying infrastructure is fixed.
+
+The ``raise_on_error`` config option to ``KafkaMetricsConfiguration`` can be set to ``False`` to raise all exceptions to the instrumented app instead of swallowing them and logging errors.
+
+The ``backoff_interval`` config option to ``KafkaMetricsConfiguration`` sets the amount of time to wait before trying to send metrics again if an error state is entered after initialization.
+
 Metrics vs. telemetry
 =====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ extend = "ruff-shared.toml"
 ]
 "safir/src/safir/testing/**" = [
     "S101",    # test support functions are allowed to use assert
+    "S311",    # test support functions needn't be cryptographically secure
 ]
 "safir/tests/data/database/*alembic/**" = [
     "INP001",  # Alembic files are magical

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -59,9 +59,9 @@ ignore = [
     "S607",     # using PATH is not a security vulnerability
     "SIM102",   # sometimes the formatting of nested if statements is clearer
     "SIM117",   # sometimes nested with contexts are clearer
-    # "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
-    # "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
-    # "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
     "TD003",    # we don't require issues be created for TODOs
     "TID252",   # if we're going to use relative imports, use them always
     "TRY003",   # good general advice but lint is way too aggressive

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -59,9 +59,9 @@ ignore = [
     "S607",     # using PATH is not a security vulnerability
     "SIM102",   # sometimes the formatting of nested if statements is clearer
     "SIM117",   # sometimes nested with contexts are clearer
-    "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
-    "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
-    "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
+    # "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
+    # "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
+    # "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
     "TD003",    # we don't require issues be created for TODOs
     "TID252",   # if we're going to use relative imports, use them always
     "TRY003",   # good general advice but lint is way too aggressive

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "scriv",
     "sqlalchemy[mypy]",
     "testcontainers[postgres,redis]",
+    "time-machine>=2.16.0",
     "uvicorn",
     # documentation
     "documenteer[guide]>=2.0.0",

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -10,6 +10,7 @@ from ._config import (
 from ._event_manager import (
     EventManager,
     EventPublisher,
+    FailedEventPublisher,
     KafkaEventManager,
     KafkaEventPublisher,
     MockEventManager,
@@ -49,6 +50,7 @@ __all__ = [
     "EventPayload",
     "EventPublisher",
     "EventsConfiguration",
+    "FailedEventPublisher",
     "KafkaEventManager",
     "KafkaEventPublisher",
     "KafkaMetricsConfiguration",

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -21,6 +21,8 @@ from ._exceptions import (
     DuplicateEventError,
     EventManagerUnintializedError,
     KafkaTopicError,
+    UnabandonableError,
+    UnsupportedAvroSchemaError,
 )
 from ._models import EventMetadata, EventPayload
 from ._testing import (
@@ -62,5 +64,7 @@ __all__ = [
     "PublishedCountError",
     "PublishedList",
     "PublishedTooFewError",
+    "UnabandonableError",
+    "UnsupportedAvroSchemaError",
     "metrics_configuration_factory",
 ]

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -21,8 +21,8 @@ from ._event_manager import (
 from ._exceptions import (
     DuplicateEventError,
     EventManagerUnintializedError,
+    EventManagerUsageError,
     KafkaTopicError,
-    UnabandonableError,
     UnsupportedAvroSchemaError,
 )
 from ._models import EventMetadata, EventPayload
@@ -46,6 +46,7 @@ __all__ = [
     "DuplicateEventError",
     "EventManager",
     "EventManagerUnintializedError",
+    "EventManagerUsageError",
     "EventMetadata",
     "EventPayload",
     "EventPublisher",
@@ -66,7 +67,6 @@ __all__ = [
     "PublishedCountError",
     "PublishedList",
     "PublishedTooFewError",
-    "UnabandonableError",
     "UnsupportedAvroSchemaError",
     "metrics_configuration_factory",
 ]

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -13,10 +13,13 @@ from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from structlog.stdlib import BoundLogger
 
+from safir.pydantic._types import HumanTimedelta
+
 from ..kafka import KafkaConnectionSettings, SchemaManagerSettings
 from ._constants import (
     ADMIN_CLIENT_PREFIX,
     BROKER_PREFIX,
+    EVENT_MANAGER_DEFAULT_BACKOFF_INTERVAL,
     EVENT_MANAGER_DEFAULT_KAFKA_TIMEOUT_MS,
 )
 from ._event_manager import (
@@ -244,6 +247,15 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
         ),
     )
 
+    backoff_interval: HumanTimedelta = Field(
+        EVENT_MANAGER_DEFAULT_BACKOFF_INTERVAL,
+        title="Backoff interval",
+        description=(
+            "The amount of time to wait until further operations are attempted"
+            " when the event manager is in an error state."
+        ),
+    )
+
     @override
     def make_manager(
         self,
@@ -279,6 +291,7 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
             schema_manager=schema_manager,
             manage_kafka_broker=manage_kafka_broker,
             raise_on_error=self.raise_on_error,
+            backoff_interval=self.backoff_interval,
             logger=logger,
         )
 

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -232,6 +232,18 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
         title="Kafka schema manager settings",
     )
 
+    raise_on_error: bool = Field(
+        False,
+        title="Raise on error",
+        description=(
+            "True if we should raise an exception whenever there is an error"
+            " with the metrics system dependencies, like Kafka or the Schema"
+            " Manager. False if we should just log an error instead. This"
+            " should be False for most production apps so that issues with the"
+            " metrics infrastructure don't bring down the app."
+        ),
+    )
+
     @override
     def make_manager(
         self,
@@ -266,6 +278,7 @@ class KafkaMetricsConfiguration(BaseMetricsConfiguration):
             kafka_admin_client=kafka_admin_client,
             schema_manager=schema_manager,
             manage_kafka_broker=manage_kafka_broker,
+            raise_on_error=self.raise_on_error,
             logger=logger,
         )
 

--- a/safir/src/safir/metrics/_config.py
+++ b/safir/src/safir/metrics/_config.py
@@ -13,7 +13,7 @@ from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from structlog.stdlib import BoundLogger
 
-from safir.pydantic._types import HumanTimedelta
+from safir.pydantic import HumanTimedelta
 
 from ..kafka import KafkaConnectionSettings, SchemaManagerSettings
 from ._constants import (

--- a/safir/src/safir/metrics/_constants.py
+++ b/safir/src/safir/metrics/_constants.py
@@ -1,5 +1,7 @@
 """Constants for metrics functionality."""
 
+from datetime import timedelta
+
 BROKER_PREFIX = "safir-metrics-faststream-broker"
 """Prefix for the Kafka client id for the metrics FastStream broker."""
 
@@ -8,3 +10,6 @@ ADMIN_CLIENT_PREFIX = "safir-metrics-admin-client"
 
 EVENT_MANAGER_DEFAULT_KAFKA_TIMEOUT_MS = 1000
 """How long to wait for Kafka before raising an error for a blocking call."""
+
+EVENT_MANAGER_DEFAULT_BACKOFF_INTERVAL = timedelta(seconds=300)
+"""Amount of time to wait before taking event manager out of error mode."""

--- a/safir/src/safir/metrics/_constants.py
+++ b/safir/src/safir/metrics/_constants.py
@@ -5,3 +5,6 @@ BROKER_PREFIX = "safir-metrics-faststream-broker"
 
 ADMIN_CLIENT_PREFIX = "safir-metrics-admin-client"
 """Prefix for the client id for the metrics Kafka admin client."""
+
+EVENT_MANAGER_DEFAULT_KAFKA_TIMEOUT_MS = 1000
+"""How long to wait for Kafka before raising an error for a blocking call."""

--- a/safir/src/safir/metrics/_exceptions.py
+++ b/safir/src/safir/metrics/_exceptions.py
@@ -4,14 +4,29 @@ __all__ = [
     "DuplicateEventError",
     "EventManagerUnintializedError",
     "KafkaTopicError",
+    "UnabandonableError",
+    "UnsupportedAvroSchemaError",
 ]
 
 
-class EventManagerUnintializedError(Exception):
+class UnabandonableError(Exception):
+    """These exceptions should be raised even in abandonable methods.
+
+    They represent application errors that can and should be fixed, vs. errors
+    with infrastructure outside of the application's control, like the
+    underlying Kafka infrastructure.
+    """
+
+
+class UnsupportedAvroSchemaError(UnabandonableError):
+    """Event model is not serializable to Avro."""
+
+
+class EventManagerUnintializedError(UnabandonableError):
     """An attempt to create a publisher after manager has been initialized."""
 
 
-class DuplicateEventError(Exception):
+class DuplicateEventError(UnabandonableError):
     """Two publishers were registered with the same name."""
 
     def __init__(self, name: str) -> None:
@@ -22,7 +37,7 @@ class DuplicateEventError(Exception):
         )
 
 
-class KafkaTopicError(Exception):
+class KafkaTopicError(UnabandonableError):
     """A topic does not exist in Kafka, or we don't have access to it."""
 
     def __init__(self, topic: str) -> None:

--- a/safir/src/safir/metrics/_exceptions.py
+++ b/safir/src/safir/metrics/_exceptions.py
@@ -3,13 +3,13 @@
 __all__ = [
     "DuplicateEventError",
     "EventManagerUnintializedError",
+    "EventManagerUsageError",
     "KafkaTopicError",
-    "UnabandonableError",
     "UnsupportedAvroSchemaError",
 ]
 
 
-class UnabandonableError(Exception):
+class EventManagerUsageError(Exception):
     """These exceptions should be raised even in abandonable methods.
 
     They represent application errors that can and should be fixed, vs. errors
@@ -18,15 +18,15 @@ class UnabandonableError(Exception):
     """
 
 
-class UnsupportedAvroSchemaError(UnabandonableError):
+class UnsupportedAvroSchemaError(EventManagerUsageError):
     """Event model is not serializable to Avro."""
 
 
-class EventManagerUnintializedError(UnabandonableError):
+class EventManagerUnintializedError(EventManagerUsageError):
     """An attempt to create a publisher after manager has been initialized."""
 
 
-class DuplicateEventError(UnabandonableError):
+class DuplicateEventError(EventManagerUsageError):
     """Two publishers were registered with the same name."""
 
     def __init__(self, name: str) -> None:
@@ -37,7 +37,7 @@ class DuplicateEventError(UnabandonableError):
         )
 
 
-class KafkaTopicError(UnabandonableError):
+class KafkaTopicError(EventManagerUsageError):
     """A topic does not exist in Kafka, or we don't have access to it."""
 
     def __init__(self, topic: str) -> None:

--- a/safir/src/safir/metrics/_models.py
+++ b/safir/src/safir/metrics/_models.py
@@ -5,6 +5,7 @@ from typing import Any
 from dataclasses_avroschema.pydantic import AvroBaseModel
 from pydantic import UUID4, AwareDatetime, Field, create_model
 
+from safir.metrics._exceptions import UnsupportedAvroSchemaError
 __all__ = ["EventMetadata", "EventPayload"]
 
 
@@ -110,7 +111,7 @@ class EventPayload(AvroBaseModel):
                 f"Supported avro types are these (or unions of these):"
                 f" {valids}"
             )
-            raise ValueError("\n".join(errors))
+            raise UnsupportedAvroSchemaError("\n".join(errors))
 
     @classmethod
     def _extract_type(cls, spec: str | dict[str, dict[str, Any]]) -> str:

--- a/safir/src/safir/metrics/_models.py
+++ b/safir/src/safir/metrics/_models.py
@@ -6,6 +6,7 @@ from dataclasses_avroschema.pydantic import AvroBaseModel
 from pydantic import UUID4, AwareDatetime, Field, create_model
 
 from safir.metrics._exceptions import UnsupportedAvroSchemaError
+
 __all__ = ["EventMetadata", "EventPayload"]
 
 

--- a/safir/tests/conftest.py
+++ b/safir/tests/conftest.py
@@ -9,11 +9,13 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 import respx
+import structlog
 from aiokafka import AIOKafkaConsumer
 from aiokafka.admin.client import AIOKafkaAdminClient, NewTopic
 from faststream.kafka import KafkaBroker
 from pydantic import AnyUrl, HttpUrl
 from redis.asyncio import Redis
+from structlog.testing import LogCapture
 from testcontainers.core.container import Network
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
@@ -49,6 +51,16 @@ from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 
 from .support.metrics import MetricsStack, metrics_stack
 
+
+@pytest.fixture
+def log_output() -> LogCapture:
+    """Capture Structlog logs to assert against."""
+    return LogCapture()
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog(log_output: LogCapture) -> None:
+    structlog.configure(processors=[log_output])
 
 
 @pytest.fixture(scope="session")

--- a/safir/tests/conftest.py
+++ b/safir/tests/conftest.py
@@ -4,28 +4,17 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Generator, Iterator
 from datetime import timedelta
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
 import respx
 import structlog
-from aiokafka import AIOKafkaConsumer
-from aiokafka.admin.client import AIOKafkaAdminClient, NewTopic
-from faststream.kafka import KafkaBroker
-from pydantic import AnyUrl, HttpUrl
+from aiokafka.admin.client import NewTopic
 from redis.asyncio import Redis
 from structlog.testing import LogCapture
-from testcontainers.core.container import Network
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
-from safir.kafka import (
-    KafkaConnectionSettings,
-    PydanticSchemaManager,
-    SchemaManagerSettings,
-    SecurityProtocol,
-)
 from safir.metrics import (
     EventManager,
     EventsConfiguration,
@@ -36,10 +25,6 @@ from safir.sentry import (
     fingerprint_env_handler,
     sentry_exception_handler,
 )
-from safir.testing.containers import (
-    FullKafkaContainer,
-    SchemaRegistryContainer,
-)
 from safir.testing.gcs import MockStorageClient, patch_google_storage
 from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from safir.testing.sentry import (
@@ -49,7 +34,13 @@ from safir.testing.sentry import (
 )
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 
-from .support.metrics import MetricsStack, metrics_stack
+from .support.kafka import (
+    KafkaClients,
+    KafkaStack,
+    make_kafka_clients,
+    make_kafka_stack,
+)
+from .support.metrics import MetricsStack, make_metrics_stack
 
 
 @pytest.fixture
@@ -64,194 +55,42 @@ def configure_structlog(log_output: LogCapture) -> None:
 
 
 @pytest.fixture(scope="session")
-def kafka_docker_network() -> Iterator[Network]:
-    """Provide a network object to link session-scoped testcontainers."""
-    with Network() as network:
-        yield network
-
-
-@pytest.fixture(scope="session")
-def kafka_cert_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    return tmp_path_factory.mktemp("kafka-certs")
-
-
-@pytest.fixture(scope="session")
-def global_kafka_container(
-    kafka_docker_network: Network, kafka_cert_path: Path
-) -> Iterator[FullKafkaContainer]:
-    """Provide a session-scoped kafka container.
-
-    You proably want one of the dependent test-scoped fixtures that clears
-    kafka data, like:
-    * ``kafka_container``
-    * ``kafka_broker``
-    * ``kafka_consumer``
-    * ``kafka_admin_client``
-    """
-    container = FullKafkaContainer()
-    container.with_network(kafka_docker_network)
-    container.with_network_aliases("kafka")
-    with container as kafka:
-        for filename in ("ca.crt", "client.crt", "client.key"):
-            contents = container.get_secret_file_contents(filename)
-            (kafka_cert_path / filename).write_text(contents)
-        yield kafka
-
-
-@pytest.fixture
-def kafka_container(
-    global_kafka_container: FullKafkaContainer,
-) -> Iterator[FullKafkaContainer]:
-    """Yield the global kafka container, but rid it of data post-test."""
-    global_kafka_container.reset()
-    return global_kafka_container
-
-
-@pytest.fixture
-def kafka_connection_settings(
-    kafka_container: FullKafkaContainer,
-) -> KafkaConnectionSettings:
-    """Provide a url to a session-scoped kafka container.
-
-    All data is cleared from the kafka instance at the end of the test.
-    """
-    return KafkaConnectionSettings(
-        bootstrap_servers=kafka_container.get_bootstrap_server(),
-        security_protocol=SecurityProtocol.PLAINTEXT,
-    )
-
-
-@pytest_asyncio.fixture
-async def kafka_consumer(
-    kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncGenerator[AIOKafkaConsumer]:
-    """Provide an AOIKafkaConsumer pointed at a session-scoped kafka container.
-
-    All data is cleared from the kafka instance at the end of the test.
-    """
-    consumer = AIOKafkaConsumer(
-        **kafka_connection_settings.to_aiokafka_params(),
-        client_id="pytest-consumer",
-    )
-    await consumer.start()
-    yield consumer
-    await consumer.stop()
-
-
-@pytest_asyncio.fixture
-async def kafka_broker(
-    kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncGenerator[KafkaBroker]:
-    """Provide a fast stream KafkaBroker pointed at a session-scoped kafka
-    container.
-
-    All data is cleared from the kafka instance at the end of the test.
-    """
-    broker = KafkaBroker(
-        **kafka_connection_settings.to_faststream_params(),
-        client_id="pytest-broker",
-    )
-    await broker.start()
-    yield broker
-    await broker.close()
-
-
-@pytest_asyncio.fixture
-async def kafka_admin_client(
-    kafka_connection_settings: KafkaConnectionSettings,
-) -> AsyncGenerator[AIOKafkaAdminClient]:
-    """Provide an AOIKafkaAdmin client pointed at a session-scoped kafka
-    container.
-
-    All data is cleared from the kafka instance at the end of the test.
-    """
-    client = AIOKafkaAdminClient(
-        **kafka_connection_settings.to_aiokafka_params(),
-        client_id="pytest-admin",
-    )
-    await client.start()
-    yield client
-    await client.close()
-
-
-@pytest.fixture(scope="session")
-def global_schema_registry_container(
-    global_kafka_container: FullKafkaContainer, kafka_docker_network: Network
-) -> Iterator[SchemaRegistryContainer]:
-    """Provide a session-scoped schema registry container that can talk to the
-    containers in other docker-based kafka fixtures.
-
-    You probably want one of the dependent test-scoped fixtures that clears
-    registry data, like ``schema_registry_connection_settings`` or
-    ``schema_manager``.
-    """
-    container = SchemaRegistryContainer(network=kafka_docker_network)
-    container.with_network(kafka_docker_network)
-    container.with_network_aliases("schemaregistry")
-    with container as schema_registry:
-        yield schema_registry
-
-
-@pytest.fixture
-def schema_registry_container(
-    global_schema_registry_container: SchemaRegistryContainer,
-) -> Iterator[SchemaRegistryContainer]:
-    """Yield the global schema registry container and rid of data post-test."""
-    yield global_schema_registry_container
-    global_schema_registry_container.reset()
-
-
-@pytest.fixture
-def schema_manager_settings(
-    schema_registry_container: SchemaRegistryContainer,
-) -> SchemaManagerSettings:
-    """Provide a URL to a session-scoped schema registry.
-
-    All data is cleared from it at the end of the test.
-    """
-    return SchemaManagerSettings(
-        registry_url=AnyUrl(schema_registry_container.get_url())
-    )
-
-
-@pytest.fixture
-def schema_manager(
-    schema_manager_settings: SchemaManagerSettings,
-) -> PydanticSchemaManager:
-    """Provide a PydanticSchemaManager pointed at a session-scoped schema
-    registry container.
-
-    All data is cleared from the registry at the end of the test.
-    """
-    return schema_manager_settings.make_manager()
-
-
-@pytest_asyncio.fixture
-async def function_scoped_metrics_stack(
-    tmp_path: Path,
-) -> AsyncGenerator[MetricsStack]:
-    """Provide function-scoped metrics infrastructure.
-
-    This is useful for testing error-handling that involves stopping the
-    container mid-test. Any tests against assumed-healthy kafka infrastructure
-    should use one of the session-scoped fixtures.
-    """
-    async with metrics_stack(tmp_path) as stack:
+def session_kafka_stack(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[KafkaStack]:
+    kafka_cert_path = tmp_path_factory.mktemp("kafka-certs")
+    with make_kafka_stack(kafka_cert_path=kafka_cert_path) as stack:
         yield stack
+
+
+@pytest.fixture
+def kafka_stack(
+    session_kafka_stack: KafkaStack,
+) -> KafkaStack:
+    session_kafka_stack.kafka_container.reset()
+    session_kafka_stack.schema_registry_container.reset()
+    return session_kafka_stack
+
+
+@pytest_asyncio.fixture
+async def kafka_clients(
+    kafka_stack: KafkaStack,
+) -> AsyncGenerator[KafkaClients]:
+    async with make_kafka_clients(kafka_stack) as clients:
+        yield clients
 
 
 @pytest_asyncio.fixture
 async def event_manager(
-    kafka_connection_settings: KafkaConnectionSettings,
-    schema_manager_settings: SchemaManagerSettings,
+    kafka_stack: KafkaStack,
 ) -> AsyncGenerator[EventManager]:
     """Provide an event manager and create a matching Kafka topic."""
     config = KafkaMetricsConfiguration(
         application="testapp",
         enabled=True,
         events=EventsConfiguration(topic_prefix="what.ever"),
-        kafka=kafka_connection_settings,
-        schema_manager=schema_manager_settings,
+        kafka=kafka_stack.kafka_connection_settings,
+        schema_manager=kafka_stack.schema_manager_settings,
     )
 
     manager = config.make_manager()
@@ -266,53 +105,36 @@ async def event_manager(
     await manager.aclose()
 
 
-@pytest_asyncio.fixture
-async def event_manager_no_kafka_no_raises() -> AsyncGenerator[EventManager]:
-    """Test app resiliency when using metrics with a bad Kafka."""
-    bad_kafka_settings = KafkaConnectionSettings(
-        bootstrap_servers="nope:1234,nada:5678",
-        security_protocol=SecurityProtocol.PLAINTEXT,
-    )
-
-    bad_schema_manager_settings = SchemaManagerSettings(
-        registry_url=HttpUrl("https://nope.com")
-    )
-    config = KafkaMetricsConfiguration(
-        application="testapp",
-        enabled=True,
-        events=EventsConfiguration(topic_prefix="what.ever"),
-        kafka=bad_kafka_settings,
-        schema_manager=bad_schema_manager_settings,
-    )
-
-    manager = config.make_manager()
-    yield manager
-    await manager.aclose()
+@pytest.fixture
+def test_scoped_kafka_stack(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[KafkaStack]:
+    kafka_cert_path = tmp_path_factory.mktemp("kafka-certs")
+    with make_kafka_stack(
+        kafka_cert_path=kafka_cert_path, constant_host_ports=True
+    ) as stack:
+        yield stack
 
 
 @pytest_asyncio.fixture
-async def event_manager_no_kafka_raises() -> AsyncGenerator[EventManager]:
-    """Test app resiliency when using metrics with a bad Kafka."""
-    bad_kafka_settings = KafkaConnectionSettings(
-        bootstrap_servers="nope:1234,nada:5678",
-        security_protocol=SecurityProtocol.PLAINTEXT,
-    )
+async def test_scoped_kafka_clients(
+    test_scoped_kafka_stack: KafkaStack,
+) -> AsyncGenerator[KafkaClients]:
+    async with make_kafka_clients(test_scoped_kafka_stack) as clients:
+        yield clients
 
-    bad_schema_manager_settings = SchemaManagerSettings(
-        registry_url=HttpUrl("https://nope.com")
-    )
-    config = KafkaMetricsConfiguration(
-        application="testapp",
-        enabled=True,
-        events=EventsConfiguration(topic_prefix="what.ever"),
-        kafka=bad_kafka_settings,
-        schema_manager=bad_schema_manager_settings,
-        raise_on_error=True,
-    )
 
-    manager = config.make_manager()
-    yield manager
-    await manager.aclose()
+@pytest_asyncio.fixture
+async def resiliency_metrics_stack(
+    test_scoped_kafka_stack: KafkaStack,
+    test_scoped_kafka_clients: KafkaClients,
+) -> AsyncGenerator[MetricsStack]:
+    async with make_metrics_stack(
+        kafka_stack=test_scoped_kafka_stack,
+        kafka_clients=test_scoped_kafka_clients,
+        kafka_max_batch_size=1,
+    ) as stack:
+        yield stack
 
 
 @pytest.fixture(scope="session")

--- a/safir/tests/conftest.py
+++ b/safir/tests/conftest.py
@@ -237,6 +237,55 @@ async def event_manager(
     await manager.aclose()
 
 
+@pytest_asyncio.fixture
+async def event_manager_no_kafka_no_raises() -> AsyncGenerator[EventManager]:
+    """Test app resiliency when using metrics with a bad Kafka."""
+    bad_kafka_settings = KafkaConnectionSettings(
+        bootstrap_servers="nope:1234,nada:5678",
+        security_protocol=SecurityProtocol.PLAINTEXT,
+    )
+
+    bad_schema_manager_settings = SchemaManagerSettings(
+        registry_url=HttpUrl("https://nope.com")
+    )
+    config = KafkaMetricsConfiguration(
+        application="testapp",
+        enabled=True,
+        events=EventsConfiguration(topic_prefix="what.ever"),
+        kafka=bad_kafka_settings,
+        schema_manager=bad_schema_manager_settings,
+    )
+
+    manager = config.make_manager()
+    yield manager
+    await manager.aclose()
+
+
+@pytest_asyncio.fixture
+async def event_manager_no_kafka_raises() -> AsyncGenerator[EventManager]:
+    """Test app resiliency when using metrics with a bad Kafka."""
+    bad_kafka_settings = KafkaConnectionSettings(
+        bootstrap_servers="nope:1234,nada:5678",
+        security_protocol=SecurityProtocol.PLAINTEXT,
+    )
+
+    bad_schema_manager_settings = SchemaManagerSettings(
+        registry_url=HttpUrl("https://nope.com")
+    )
+    config = KafkaMetricsConfiguration(
+        application="testapp",
+        enabled=True,
+        events=EventsConfiguration(topic_prefix="what.ever"),
+        kafka=bad_kafka_settings,
+        schema_manager=bad_schema_manager_settings,
+        raise_on_error=True,
+    )
+
+    manager = config.make_manager()
+    yield manager
+    await manager.aclose()
+
+
 @pytest.fixture(scope="session")
 def database_password() -> str:
     return "INSECURE@%PASSWORD/"

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -313,9 +313,7 @@ async def test_invalid_payload(event_manager: EventManager) -> None:
         bad_union_field: dict[str, str] | None = Field()
         bad_dict_field: dict[str, str] = Field()
 
-    with pytest.raises(
-        UnsupportedAvroSchemaError, match="Unsupported Avro Schema"
-    ) as excinfo:
+    with pytest.raises(UnsupportedAvroSchemaError) as excinfo:
         await event_manager.create_publisher("myinvalidevent", MyInvalidEvent)
     err = str(excinfo.value)
 

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -40,6 +40,7 @@ from safir.metrics import (
     KafkaMetricsConfiguration,
     KafkaTopicError,
 )
+from safir.metrics._exceptions import UnsupportedAvroSchemaError
 
 
 class MyEvent(EventPayload):
@@ -307,7 +308,9 @@ async def test_invalid_payload(event_manager: EventManager) -> None:
         bad_union_field: dict[str, str] | None = Field()
         bad_dict_field: dict[str, str] = Field()
 
-    with pytest.raises(ValueError, match="Unsupported Avro Schema") as excinfo:
+    with pytest.raises(
+        UnsupportedAvroSchemaError, match="Unsupported Avro Schema"
+    ) as excinfo:
         await event_manager.create_publisher("myinvalidevent", MyInvalidEvent)
     err = str(excinfo.value)
 

--- a/safir/tests/support/kafka.py
+++ b/safir/tests/support/kafka.py
@@ -1,0 +1,208 @@
+"""Support for testing Kafka helpers."""
+
+import logging
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from aiokafka import AIOKafkaConsumer
+from aiokafka.admin import AIOKafkaAdminClient
+from docker.errors import NotFound
+from faststream.kafka import KafkaBroker
+from pydantic import AnyUrl
+from schema_registry.client import AsyncSchemaRegistryClient
+from testcontainers.core.network import Network
+
+from safir.kafka import (
+    KafkaConnectionSettings,
+    SchemaManagerSettings,
+    SecurityProtocol,
+)
+from safir.kafka._manager import PydanticSchemaManager
+from safir.testing.containers import (
+    FullKafkaContainer,
+    SchemaRegistryContainer,
+)
+
+__all__ = [
+    "KafkaClients",
+    "KafkaStack",
+    "make_kafka_clients",
+    "make_kafka_stack",
+]
+
+
+@dataclass
+class KafkaStack:
+    """Objects and external services in a full app metrics stack."""
+
+    kafka_container: FullKafkaContainer
+    """A Kafka docker TestContainer."""
+
+    kafka_cert_path: Path
+    """The local path containing the Kafka certs."""
+
+    schema_registry_container: SchemaRegistryContainer
+    """A schema registry TestContainer."""
+
+    kafka_connection_settings: KafkaConnectionSettings
+    """Connection settings for the Kafka container."""
+
+    schema_manager_settings: SchemaManagerSettings
+    """Settings for a schema manager pointed at the stack."""
+
+
+@dataclass
+class KafkaClients:
+    """Clients for pieces of the Kafka stack."""
+
+    kafka_consumer: AIOKafkaConsumer
+    """An AIOKafkaConsumer pointed at the stack."""
+
+    kafka_broker: KafkaBroker
+    """A faststream KafkaBroker pointed at the stack."""
+
+    kafka_admin_client: AIOKafkaAdminClient
+    """An AIOKafkaAdminClient pointed at the stack."""
+
+    schema_registry_client: AsyncSchemaRegistryClient
+    """A schema registry client pointed at the stack."""
+
+    schema_manager: PydanticSchemaManager
+    """A PydanticSchemaManager pointed at the stack."""
+
+
+@contextmanager
+def make_kafka_stack(
+    kafka_cert_path: Path, *, constant_host_ports: bool = False
+) -> Generator[KafkaStack]:
+    """Yield a full kafka stack with clients and underlying infrastructure.
+
+    Parameters
+    ----------
+    kafka_cert_path
+        The local path to Kafka cert files. Probably comes from a
+        tmp_path_factory fixture.
+    constant_host_ports
+        Whether or not the Kafka container should use explicitly numbered host
+        ports. This is needed for tests that stop and restart the Kafka
+        container so that it comes back up with the same mapped host ports.
+    """
+    kafka_container = None
+    schema_registry_container = None
+    network = None
+    try:
+        network = Network().create()
+        kafka_container = FullKafkaContainer(
+            constant_host_ports=constant_host_ports
+        )
+        kafka_container.with_network(network)
+        kafka_container.with_network_aliases("kafka")
+
+        kafka_container.start()
+
+        for filename in ("ca.crt", "client.crt", "client.key"):
+            contents = kafka_container.get_secret_file_contents(filename)
+            (kafka_cert_path / filename).write_text(contents)
+
+        kafka_connection_settings = KafkaConnectionSettings(
+            bootstrap_servers=kafka_container.get_bootstrap_server(),
+            security_protocol=SecurityProtocol.PLAINTEXT,
+        )
+        schema_registry_container = SchemaRegistryContainer(network=network)
+        schema_registry_container.with_network(network)
+        schema_registry_container.with_network_aliases("schemaregistry")
+
+        schema_registry_container.start()
+
+        schema_manager_settings = SchemaManagerSettings(
+            registry_url=AnyUrl(schema_registry_container.get_url())
+        )
+
+        yield KafkaStack(
+            kafka_container=kafka_container,
+            kafka_cert_path=kafka_cert_path,
+            schema_registry_container=schema_registry_container,
+            kafka_connection_settings=kafka_connection_settings,
+            schema_manager_settings=schema_manager_settings,
+        )
+
+    finally:
+        if kafka_container:
+            try:
+                kafka_container.stop()
+            except NotFound:
+                logging.getLogger().info(
+                    "Trying to stop Kafka container, but it doesn't exist."
+                    " This is fine if the container was stopped in the test"
+                    " itself."
+                )
+
+        if schema_registry_container:
+            try:
+                schema_registry_container.stop()
+            except NotFound:
+                logging.getLogger().info(
+                    "Trying to stop Schema Registry container, but it doesn't"
+                    " exist. This is fine if the container was stopped in the"
+                    " test itself."
+                )
+        if network:
+            network.remove()
+
+
+@asynccontextmanager
+async def make_kafka_clients(
+    stack: KafkaStack,
+) -> AsyncGenerator[KafkaClients]:
+    """Yield a bucket of useful Kafka and schema manager clients.
+
+    Parameters
+    ----------
+    stack
+        The containers to point the clients at.
+    """
+    kafka_consumer = None
+    kafka_broker = None
+    kafka_admin_client = None
+
+    try:
+        schema_registry_client = AsyncSchemaRegistryClient(
+            **stack.schema_manager_settings.to_registry_params()
+        )
+
+        kafka_consumer = AIOKafkaConsumer(
+            **stack.kafka_connection_settings.to_aiokafka_params(),
+            client_id="pytest-consumer",
+        )
+        await kafka_consumer.start()
+
+        kafka_broker = KafkaBroker(
+            **stack.kafka_connection_settings.to_faststream_params(),
+            client_id="pytest-broker",
+        )
+        await kafka_broker.start()
+
+        kafka_admin_client = AIOKafkaAdminClient(
+            **stack.kafka_connection_settings.to_aiokafka_params(),
+            client_id="pytest-admin",
+        )
+        await kafka_admin_client.start()
+
+        schema_manager = stack.schema_manager_settings.make_manager()
+
+        yield KafkaClients(
+            schema_registry_client=schema_registry_client,
+            kafka_consumer=kafka_consumer,
+            kafka_broker=kafka_broker,
+            kafka_admin_client=kafka_admin_client,
+            schema_manager=schema_manager,
+        )
+    finally:
+        if kafka_consumer:
+            await kafka_consumer.stop()
+        if kafka_broker:
+            await kafka_broker.close()
+        if kafka_admin_client:
+            await kafka_admin_client.close()

--- a/safir/tests/support/metrics.py
+++ b/safir/tests/support/metrics.py
@@ -1,0 +1,135 @@
+"""Helpers for app metrics testing."""
+
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+from aiokafka.admin.client import NewTopic
+from docker.errors import NotFound
+from pydantic import AnyUrl
+from schema_registry.client import AsyncSchemaRegistryClient
+from testcontainers.core.network import Network
+
+from safir.kafka import (
+    KafkaConnectionSettings,
+    SchemaManagerSettings,
+    SecurityProtocol,
+)
+from safir.metrics import EventsConfiguration, KafkaMetricsConfiguration
+from safir.metrics._event_manager import KafkaEventManager
+from safir.testing.containers import (
+    FullKafkaContainer,
+    SchemaRegistryContainer,
+)
+
+__all__ = ["MetricsStack", "metrics_stack"]
+
+
+@dataclass
+class MetricsStack:
+    """Objects and external services in a full app metrics stack."""
+
+    event_manager: KafkaEventManager
+    kafka_container: FullKafkaContainer
+    kafka_connection_settings: KafkaConnectionSettings
+    schema_registry_client: AsyncSchemaRegistryClient
+    max_batch_size: int
+    metrics_config: KafkaMetricsConfiguration
+
+
+@asynccontextmanager
+async def metrics_stack(
+    tmp_path: Path,
+) -> AsyncGenerator[MetricsStack]:
+    """Yield a full metrics stack with underlying infrastructure."""
+    cert_path = tmp_path / "kafka-certs"
+    cert_path.mkdir()
+
+    # We want to set this as log as possible so we can trigger an exception in
+    # the EventManager publish method. This only happens when we send messages
+    # at such a rate that a batch fills up before aiokafka can send it in the
+    # background.
+    max_batch_size = 1
+
+    with Network() as network:
+        kafka_container = FullKafkaContainer(constant_host_ports=True)
+        kafka_container.with_network(network)
+        kafka_container.with_network_aliases("kafka")
+
+        kafka_container.start()
+
+        for filename in ("ca.crt", "client.crt", "client.key"):
+            contents = kafka_container.get_secret_file_contents(filename)
+            (cert_path / filename).write_text(contents)
+
+        kafka_connection_settings = KafkaConnectionSettings(
+            bootstrap_servers=kafka_container.get_bootstrap_server(),
+            security_protocol=SecurityProtocol.PLAINTEXT,
+        )
+        schema_registry_container = SchemaRegistryContainer(network=network)
+        schema_registry_container.with_network(network)
+        schema_registry_container.with_network_aliases("schemaregistry")
+
+        schema_registry_container.start()
+
+        schema_manager_settings = SchemaManagerSettings(
+            registry_url=AnyUrl(schema_registry_container.get_url())
+        )
+        config = KafkaMetricsConfiguration(
+            application="testapp",
+            enabled=True,
+            events=EventsConfiguration(topic_prefix="what.ever"),
+            kafka=kafka_connection_settings,
+            schema_manager=schema_manager_settings,
+            # This should be longer than it takes to restart the Kafka
+            # container in a test. We're going to fake time in the test so we
+            # can advance it quickly
+            backoff_interval=timedelta(hours=1),
+        )
+
+        manager = config.make_manager(
+            extra_broker_settings={
+                "max_batch_size": max_batch_size,
+            }
+        )
+        await manager.initialize()
+        topic = NewTopic(
+            name="what.ever.testapp",
+            num_partitions=1,
+            replication_factor=1,
+        )
+        await manager._admin_client.create_topics([topic])
+
+        schema_registry_client = AsyncSchemaRegistryClient(
+            **schema_manager_settings.to_registry_params()
+        )
+
+        yield MetricsStack(
+            event_manager=manager,
+            kafka_container=kafka_container,
+            kafka_connection_settings=kafka_connection_settings,
+            schema_registry_client=schema_registry_client,
+            max_batch_size=max_batch_size,
+            metrics_config=config,
+        )
+        await manager.aclose()
+
+        try:
+            kafka_container.stop()
+        except NotFound:
+            logging.getLogger().info(
+                "Trying to stop Kafka container, but it doesn't exist. This is"
+                " fine if the container was stopped in the test itself."
+            )
+
+        try:
+            schema_registry_container.stop()
+        except NotFound:
+            logging.getLogger().info(
+                "Trying to stop Schema Registry container, but it doesn't"
+                " exist. This is fine if the container was stopped in the test"
+                " itself."
+            )

--- a/safir/tests/support/metrics.py
+++ b/safir/tests/support/metrics.py
@@ -33,11 +33,26 @@ class MetricsStack:
     """Objects and external services in a full app metrics stack."""
 
     event_manager: KafkaEventManager
+    """An uninialized Kafka event manager."""
+
     kafka_container: FullKafkaContainer
+    """A Kafka docker TestContainer."""
+
     kafka_connection_settings: KafkaConnectionSettings
+    """Connection settings for the Kafka container."""
+
     schema_registry_client: AsyncSchemaRegistryClient
+    """A schema registry client for the schema registry in the stack."""
+
     max_batch_size: int
+    """The maximum number of messages to keep in an aiokafka batch.
+
+    If another message is published while there are this many messages in the
+    batch, aoikafka will block to send the batch.
+    """
+
     metrics_config: KafkaMetricsConfiguration
+    """Metrics configuration for all of the services in the stack."""
 
 
 @asynccontextmanager

--- a/safir/tests/support/metrics.py
+++ b/safir/tests/support/metrics.py
@@ -1,150 +1,98 @@
 """Helpers for app metrics testing."""
 
-import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import timedelta
-from pathlib import Path
 
 from aiokafka.admin.client import NewTopic
-from docker.errors import NotFound
-from pydantic import AnyUrl
-from schema_registry.client import AsyncSchemaRegistryClient
-from testcontainers.core.network import Network
 
-from safir.kafka import (
-    KafkaConnectionSettings,
-    SchemaManagerSettings,
-    SecurityProtocol,
-)
 from safir.metrics import EventsConfiguration, KafkaMetricsConfiguration
 from safir.metrics._event_manager import KafkaEventManager
-from safir.testing.containers import (
-    FullKafkaContainer,
-    SchemaRegistryContainer,
-)
 
-__all__ = ["MetricsStack", "metrics_stack"]
+from .kafka import KafkaClients, KafkaStack
+
+__all__ = ["MetricsStack", "make_metrics_stack"]
 
 
 @dataclass
 class MetricsStack:
     """Objects and external services in a full app metrics stack."""
 
-    event_manager: KafkaEventManager
-    """An uninialized Kafka event manager."""
+    kafka_stack: KafkaStack
+    """Kafka containers and connection info."""
 
-    kafka_container: FullKafkaContainer
-    """A Kafka docker TestContainer."""
+    kafka_clients: KafkaClients
+    """Kafka clients that point at the Kafka stack."""
 
-    kafka_connection_settings: KafkaConnectionSettings
-    """Connection settings for the Kafka container."""
-
-    schema_registry_client: AsyncSchemaRegistryClient
-    """A schema registry client for the schema registry in the stack."""
-
-    max_batch_size: int
-    """The maximum number of messages to keep in an aiokafka batch.
+    kafka_max_batch_size: int
+    """The maximum number of messages to allow in an aiokafka produce batch.
 
     If another message is published while there are this many messages in the
     batch, aoikafka will block to send the batch.
     """
+
+    event_manager: KafkaEventManager
+    """An uninialized Kafka event manager."""
 
     metrics_config: KafkaMetricsConfiguration
     """Metrics configuration for all of the services in the stack."""
 
 
 @asynccontextmanager
-async def metrics_stack(
-    tmp_path: Path,
+async def make_metrics_stack(
+    *,
+    kafka_stack: KafkaStack,
+    kafka_clients: KafkaClients,
+    kafka_max_batch_size: int = 16384,
 ) -> AsyncGenerator[MetricsStack]:
-    """Yield a full metrics stack with underlying infrastructure."""
-    cert_path = tmp_path / "kafka-certs"
-    cert_path.mkdir()
+    """Yield a full metrics stack with underlying infrastructure.
 
-    # We want to set this as log as possible so we can trigger an exception in
-    # the EventManager publish method. This only happens when we send messages
-    # at such a rate that a batch fills up before aiokafka can send it in the
-    # background.
-    max_batch_size = 1
+    Parameters
+    ----------
+    kafka_stack
+        A bucket of containers.
+    kafka_clients
+        A bucket of clients that point at those containers.
+    kafka_max_batch_size
+        The maximum number of messages to allow in an aiokafka produce batch.
+        If another message is published while there are this many messages in
+        the batch, aoikafka will block to send the batch.
+    """
+    config = KafkaMetricsConfiguration(
+        application="testapp",
+        enabled=True,
+        events=EventsConfiguration(topic_prefix="what.ever"),
+        kafka=kafka_stack.kafka_connection_settings,
+        schema_manager=kafka_stack.schema_manager_settings,
+        # This should be longer than it takes to restart the Kafka
+        # container in a test. We're going to fake time in the test so we
+        # can advance it quickly
+        backoff_interval=timedelta(hours=1),
+        raise_on_error=False,
+    )
 
-    with Network() as network:
-        kafka_container = FullKafkaContainer(constant_host_ports=True)
-        kafka_container.with_network(network)
-        kafka_container.with_network_aliases("kafka")
-
-        kafka_container.start()
-
-        for filename in ("ca.crt", "client.crt", "client.key"):
-            contents = kafka_container.get_secret_file_contents(filename)
-            (cert_path / filename).write_text(contents)
-
-        kafka_connection_settings = KafkaConnectionSettings(
-            bootstrap_servers=kafka_container.get_bootstrap_server(),
-            security_protocol=SecurityProtocol.PLAINTEXT,
-        )
-        schema_registry_container = SchemaRegistryContainer(network=network)
-        schema_registry_container.with_network(network)
-        schema_registry_container.with_network_aliases("schemaregistry")
-
-        schema_registry_container.start()
-
-        schema_manager_settings = SchemaManagerSettings(
-            registry_url=AnyUrl(schema_registry_container.get_url())
-        )
-        config = KafkaMetricsConfiguration(
-            application="testapp",
-            enabled=True,
-            events=EventsConfiguration(topic_prefix="what.ever"),
-            kafka=kafka_connection_settings,
-            schema_manager=schema_manager_settings,
-            # This should be longer than it takes to restart the Kafka
-            # container in a test. We're going to fake time in the test so we
-            # can advance it quickly
-            backoff_interval=timedelta(hours=1),
-        )
-
-        manager = config.make_manager(
-            extra_broker_settings={
-                "max_batch_size": max_batch_size,
-            }
-        )
-        await manager.initialize()
+    manager = config.make_manager(
+        extra_broker_settings={
+            "max_batch_size": kafka_max_batch_size,
+        }
+    )
+    try:
         topic = NewTopic(
             name="what.ever.testapp",
             num_partitions=1,
             replication_factor=1,
         )
-        await manager._admin_client.create_topics([topic])
+        await kafka_clients.kafka_admin_client.create_topics([topic])
 
-        schema_registry_client = AsyncSchemaRegistryClient(
-            **schema_manager_settings.to_registry_params()
-        )
+        await manager.initialize()
 
         yield MetricsStack(
+            kafka_stack=kafka_stack,
+            kafka_clients=kafka_clients,
+            kafka_max_batch_size=kafka_max_batch_size,
             event_manager=manager,
-            kafka_container=kafka_container,
-            kafka_connection_settings=kafka_connection_settings,
-            schema_registry_client=schema_registry_client,
-            max_batch_size=max_batch_size,
             metrics_config=config,
         )
+    finally:
         await manager.aclose()
-
-        try:
-            kafka_container.stop()
-        except NotFound:
-            logging.getLogger().info(
-                "Trying to stop Kafka container, but it doesn't exist. This is"
-                " fine if the container was stopped in the test itself."
-            )
-
-        try:
-            schema_registry_container.stop()
-        except NotFound:
-            logging.getLogger().info(
-                "Trying to stop Schema Registry container, but it doesn't"
-                " exist. This is fine if the container was stopped in the test"
-                " itself."
-            )


### PR DESCRIPTION
This is a lot of diff, and I'm glad to split it into separate PRs if we want, but none of it makes any sense alone. I tried to make the individual commits a good guide for what's going on, but again, I'm glad to split any of those commits off into other PRs.

If the underlying app metrics infrastructure is degraded, like if Kafka or the Schema Registry are not available, the Safir app metrics code now tries very hard to not crash or your instrumented application.

Instead of of raising exceptions, it will log error-level messages and put itself into an error state. Once in this error state, it will not even try to interact with any underlying infrastructure, which means it will not even try to send metrics.
It will instead only log error messages.

If this happens during initialization, you will have to restart your app after the underlying infrastructure is fixed to start sending metrics again. If this happens after successful initialization, the app will try to send metrics again after a configurable amount of time and may succeed when the underlying infrastructure is fixed.

There are two new config options:
* The `raise_on_error` config option to `KafkaMetricsConfiguration` can be set to `False` to raise all exceptions to the instrumented app instead of swallowing them and logging errors.
* The `backoff_interval` config option to `KafkaMetricsConfiguration` sets the amount of time to wait before trying to send metrics again if an error state is entered after initialization.

## No self-healing after initialization

This sort of stinks because we if fail during initialization due to the Kafka/schema registry being unavailable, the app has to be restarted when it comes back in order to send metrics. In order to self-heal after an initialization failure, I think there has to be some bigger architectural changes.