### PR TITLE
DM-51751: Add `head` value to GitHubPullRequestModel

### DIFF
--- a/changelog.d/20250709_154628_danfuchs_HEAD.md
+++ b/changelog.d/20250709_154628_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### New features
+
+- `GitHubPullRequestModel` now contains a `head` value, which is a model that contains a `sha` value. This is the latest commit SHA on the head branch of the PR in a `GitHubPullRequestEventModel`.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -7,7 +7,7 @@
 .. _cryptography: https://cryptography.io/en/latest/
 .. _FastAPI: https://fastapi.tiangolo.com/
 .. _fastapi_safir_app: https://github.com/lsst/templates/tree/main/project_templates/fastapi_safir_app
-.. _FastStream: https://faststream.airt.ai
+.. _FastStream: https://faststream.ag2.ai
 .. _Gafaelfawr: https://gafaelfawr.lsst.io/
 .. _Gidgethub: https://gidgethub.readthedocs.io/en/latest/
 .. _HTTPX: https://www.python-httpx.org/

--- a/safir/src/safir/github/models.py
+++ b/safir/src/safir/github/models.py
@@ -21,6 +21,7 @@ __all__ = [
     "GitHubCheckSuiteId",
     "GitHubCheckSuiteModel",
     "GitHubCheckSuiteStatus",
+    "GitHubPullRequestHeadModel",
     "GitHubPullRequestModel",
     "GitHubPullState",
     "GitHubRepoOwnerModel",
@@ -141,6 +142,12 @@ class GitHubPullState(StrEnum):
     """The PR is closed."""
 
 
+class GitHubPullRequestHeadModel(BaseModel):
+    """A Pydantic model for the last commit to the head branch of a PR."""
+
+    sha: str = Field(description="Last commit SHA of the PR head branch.")
+
+
 class GitHubPullRequestModel(BaseModel):
     """A Pydantic model for a GitHub Pull Request.
 
@@ -165,6 +172,10 @@ class GitHubPullRequestModel(BaseModel):
     merged: bool = Field(description="True if the PR is merged.")
 
     user: GitHubUserModel = Field(description="The user that opened the PR.")
+
+    head: GitHubPullRequestHeadModel = Field(
+        description="The last commit to the head branch of the PR."
+    )
 
 
 class GitHubBranchCommitModel(BaseModel):

--- a/safir/tests/github/webhooks_test.py
+++ b/safir/tests/github/webhooks_test.py
@@ -70,6 +70,8 @@ def test_pull_request_event() -> None:
     assert data.action == GitHubPullRequestEventAction.opened
     assert data.pull_request.number == 2
     assert data.pull_request.title == "Update the README with new information."
+    expected_sha = "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    assert data.pull_request.head.sha == expected_sha
 
 
 def test_check_suite_completed_event() -> None:


### PR DESCRIPTION
Mobu CI is going to use [`pull_request` events](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request) instead of `check_suite` and `check_run` events. It needs to check out the repo at a specific ref. The most specific ref in the `pull_request` event is the commit hash of the last commit to the head branch of the PR, available at `.pull_request.head.sha`.

Goes with [this Mobu PR](https://github.com/lsst-sqre/mobu/pull/465)