### PR TITLE
DM-51806: Fix new legit warnings from Documenteer 2 bump

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,7 @@ API reference
 ..
    If all objects from safir.pydantic are included, the pages for the
    Pydantic types are generated but not linked into any table of contents.
-   This is probably a but in automodapi and should be checked against later
+   This is probably a bug in automodapi and should be checked against later
    verisons to see if it's fixed. Once this is fixed, the nitpick exclusions
    in documenteer.yaml can also be removed.
 

--- a/safir-arq/src/safir/arq/_exceptions.py
+++ b/safir-arq/src/safir/arq/_exceptions.py
@@ -11,13 +11,7 @@ __all__ = [
 
 
 class ArqJobError(Exception):
-    """A base class for errors related to arq jobs.
-
-    Attributes
-    ----------
-    job_id
-        The job ID, or `None` if the job ID is not known in this context.
-    """
+    """A base class for errors related to arq jobs."""
 
     def __init__(self, message: str, job_id: str | None) -> None:
         super().__init__(message)

--- a/safir-arq/src/safir/arq/uws.py
+++ b/safir-arq/src/safir/arq/uws.py
@@ -132,17 +132,8 @@ class WorkerError(Exception):
 
     Attributes
     ----------
-    cause_type
-        Type of the underlying exception, if there is one.
     detail
         Additional error detail, not including the traceback if any.
-    error_type
-        Indicates whether this exception represents a transient error that may
-        go away if the request is retried or a permanent error with the
-        request.
-    traceback
-        Traceback of the underlying triggering exception, if tracebacks were
-        requested and there is a cause set.
     user
         User whose action triggered this exception, for Slack reporting.
 

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "testcontainers[postgres,redis]",
     "uvicorn",
     # documentation
-    "documenteer[guide]>=1.4.1",
+    "documenteer[guide]>=2.0.0",
     "autodoc_pydantic",
 ]
 gcs = [

--- a/safir/src/safir/slack/blockkit.py
+++ b/safir/src/safir/slack/blockkit.py
@@ -292,7 +292,8 @@ class SlackException(Exception):
         Returns
         -------
         SlackMessage
-            Slack message suitable for posting with `SlackClient`.
+            Slack message suitable for posting with
+            `safir.slack.webhook.SlackWebhookClient`.
         """
         failed_at = format_datetime_for_logging(self.failed_at)
         fields: list[SlackBaseField] = [


### PR DESCRIPTION
Documenteer 2.0.0 was [recently released](https://documenteer.lsst.io/changelog.html#change-log). It brought with it some new warnings in the docs build. These new warnings are legit.