### PR TITLE
DM-51521: Revise documentation for current templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Safir
 
-Safir is Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Rubin Science Platform (Phalanx)](https://github.com/lsst-sqre/phalanx) and [Roundtable](https://github.com/lsst-sqre/roundtable) Kubernetes clusters.
+Safir is Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Phalanx](https://phalanx.lsst.io) Kubernetes clusters, including the Rubin Science Platform and Roundtable.
 Safir is developed, maintained, and field tested by the SQuaRE team.
 
 Safir is available from [PyPI](https://pypi.org/project/safir/):
@@ -13,15 +13,6 @@ The best way to create a new FastAPI/Safir service is with the [`fastapi_safir_a
 
 Read more about Safir at https://safir.lsst.io.
 
-## Features
-
-- Set up an `httpx.AsyncClient` as part of the application start-up and shutdown lifecycle.
-- Set up structlog-based logging.
-- Middleware for attaching request context to the logger to include a request UUID, method, and route in all log messages.
-- Process `X-Forwarded-*` headers to determine the source IP and related information of the request.
-- Gather and structure standard metadata about your application.
-- Operate a distributed Redis job queue with [arq](https://arq-docs.helpmanual.io) using convenient clients, testing mocks, and a FastAPI dependency.
-
 ## Developing Safir
 
-See https://safir.lsst.io/dev/development.html.
+See the [Safir development documentation](https://safir.lsst.io/dev/development.html).

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -31,6 +31,7 @@
 .. _Sentry: https://sentry.io/welcome/
 .. _semver: https://semver.org/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
+.. _SQuaRE Bot: https://squarebot.lsst.io/
 .. _structlog: https://www.structlog.org/en/stable/
 .. _templatekit: https://templatekit.lsst.io
 .. _Testcontainers: https://github.com/testcontainers/testcontainers-python

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -36,6 +36,7 @@
 .. _Testcontainers: https://github.com/testcontainers/testcontainers-python
 .. _tox: https://tox.wiki/en/latest/
 .. _tox-docker: https://tox-docker.readthedocs.io/en/latest/
+.. _uv: https://docs.astral.sh/uv/
 .. _Uvicorn: https://www.uvicorn.org/
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/stable/
 .. _vo-models: https://vo-models.readthedocs.io/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Safir
 #####
 
-Safir is Rubin Observatory's library for building FastAPI_ services for the Rubin Science Platform (Phalanx_) and Roundtable_ Kubernetes clusters.
+Safir is Rubin Observatory's library for building FastAPI_ services for Phalanx_ Kubernetes clusters, including the Rubin Science Platform and Roundtable.
 Safir is developed, maintained, and field tested by the SQuaRE team.
 
 Safir is developed on GitHub at https://github.com/lsst-sqre/safir and is available on PyPI_.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -9,6 +9,7 @@ User guide
    :caption: Tutorials
 
    set-up-from-template
+   template-manual
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user-guide/set-up-from-template.rst
+++ b/docs/user-guide/set-up-from-template.rst
@@ -5,7 +5,7 @@ Creating an app from the template
 #################################
 
 The best way to create a new Safir-based application is with the fastapi_safir_app_ template.
-The quickest way to do this is by running the ``/msg squarebot create project`` Slack command on the Rubin project Slack.
+The quickest way to do this is by running the ``/msg @Squarebot create project`` Slack command on the Rubin project Slack.
 
 For a manual equivalent, see :doc:`template-manual`.
 
@@ -21,7 +21,13 @@ See the `uv documentation <https://docs.astral.sh/uv/getting-started/installatio
 2. Create the project
 =====================
 
-To create a new project, run the command ``/msg squarebot create project`` on the Rubin Observatory internal project Slack.
+In the Rubin Observatory internal project Slack, ask `SQuaRE Bot`_ to create a new project:
+
+.. code-block:: text
+   :caption: rubin-obs.slack.com
+
+   /msg @Squarebot create project
+
 Select the ``FastAPI application (Safir)`` template.
 
 This will ask a series of questions to configure your new repository, and then create it from the fastapi_safir_app_ template.
@@ -30,7 +36,7 @@ If you are creating a :doc:`UWS service <uws/index>`, select the ``UWS`` flavor.
 3. Clone the repository
 =======================
 
-Squarebot will create a new GitHub repository and notify you when that is complete.
+SQuaRE Bot will create a new GitHub repository and notify you when that is complete.
 Check out that new repository with Git using the command that Squarebot gives you.
 You will be able to interact with this repository like any other GitHub repository.
 
@@ -146,4 +152,4 @@ Now that you have a working application repository, the next steps are to develo
 
 To learn learn more about developing Safir-based applications like yours, refer to the :doc:`guides in this documentation <index>` and the `FastAPI documentation <https://fastapi.tiangolo.com/>`__.
 
-To learn how to deploy your application to Phalanx, see the `Phalanx documentation <https://phalanx.lsst.io>`__.
+To learn how to deploy your application to Phalanx, see the `Phalanx developer documentation <https://phalanx.lsst.io/developers/index.html>`__.

--- a/docs/user-guide/template-manual.rst
+++ b/docs/user-guide/template-manual.rst
@@ -1,13 +1,11 @@
-.. _create-from-template:
+##########################################
+Manually creating an app from the template
+##########################################
 
-#################################
-Creating an app from the template
-#################################
+The preferred way to create a new Safir-based application is via the Squarebot bot on the Rubin Observatory internal project Slack.
+See :doc:`set-up-from-template` for instructions.
 
-The best way to create a new Safir-based application is with the fastapi_safir_app_ template.
-The quickest way to do this is by running the ``/msg squarebot create project`` Slack command on the Rubin project Slack.
-
-For a manual equivalent, see :doc:`template-manual`.
+If you do not have access to that Slack server or want full control of each step, you can instead run the following steps manually.
 
 1. Install necessary prerequisites
 ==================================
@@ -18,21 +16,40 @@ The fastapi_safir_app_ template does not support earlier versions.
 You will also need to have a recent version of uv_ installed locally.
 See the `uv documentation <https://docs.astral.sh/uv/getting-started/installation/>`__ for installation instructions.
 
-2. Create the project
-=====================
+Then, in a clean Python virtual environment, install templatekit_:
 
-To create a new project, run the command ``/msg squarebot create project`` on the Rubin Observatory internal project Slack.
-Select the ``FastAPI application (Safir)`` template.
+.. prompt:: bash
 
-This will ask a series of questions to configure your new repository, and then create it from the fastapi_safir_app_ template.
-If you are creating a :doc:`UWS service <uws/index>`, select the ``UWS`` flavor.
+   python -m pip install templatekit
 
-3. Clone the repository
-=======================
+2. Start the project with the template
+======================================
 
-Squarebot will create a new GitHub repository and notify you when that is complete.
-Check out that new repository with Git using the command that Squarebot gives you.
-You will be able to interact with this repository like any other GitHub repository.
+Next, you'll actually create the project files using the template.
+
+.. prompt:: bash
+
+   git clone https://github.com/lsst/templates
+   templatekit -r templates make fastapi_safir_app
+
+Answer the prompts, and move into that directory in your shell.
+
+The rest of this tutorial uses ``safirdemo`` as the repository (and package) name:
+
+.. prompt:: bash
+
+   cd safirdemo
+
+3. Initialize the repository
+============================
+
+From the root of the project directory, initialize the Git repository:
+
+.. prompt:: bash
+
+   git init .
+   git add .
+   git commit
 
 4. Initialize the dependencies
 ==============================
@@ -88,7 +105,12 @@ You can format the code by running tox_:
    tox run -e lint
    git commit -a
 
-6. Try the local test commands
+6. Push to GitHub
+=================
+
+Now `create your application's repository on GitHub <https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository>`__ and push to it.
+
+7. Try the local test commands
 ==============================
 
 The preferred way to run tests is with tox_:
@@ -122,7 +144,7 @@ To run all the default test steps, but in parallel:
 
    tox run-parallel -p auto
 
-7. Try the local development server
+8. Try the local development server
 ===================================
 
 In addition to running tests, tox is also configured with a command to spin up a development server:
@@ -139,11 +161,3 @@ In another shell, send an HTTP GET request to the development server:
 
 This development server auto-reloads, so any time you change the code, the server will restart for you.
 
-Next steps
-==========
-
-Now that you have a working application repository, the next steps are to develop your application's logic and interface, and then deploy it to Phalanx.
-
-To learn learn more about developing Safir-based applications like yours, refer to the :doc:`guides in this documentation <index>` and the `FastAPI documentation <https://fastapi.tiangolo.com/>`__.
-
-To learn how to deploy your application to Phalanx, see the `Phalanx documentation <https://phalanx.lsst.io>`__.

--- a/docs/user-guide/template-manual.rst
+++ b/docs/user-guide/template-manual.rst
@@ -16,12 +16,6 @@ The fastapi_safir_app_ template does not support earlier versions.
 You will also need to have a recent version of uv_ installed locally.
 See the `uv documentation <https://docs.astral.sh/uv/getting-started/installation/>`__ for installation instructions.
 
-Then, in a clean Python virtual environment, install templatekit_:
-
-.. prompt:: bash
-
-   python -m pip install templatekit
-
 2. Start the project with the template
 ======================================
 
@@ -30,7 +24,7 @@ Next, you'll actually create the project files using the template.
 .. prompt:: bash
 
    git clone https://github.com/lsst/templates
-   templatekit -r templates make fastapi_safir_app
+   uvx templatekit -r templates make fastapi_safir_app
 
 Answer the prompts, and move into that directory in your shell.
 

--- a/safir-arq/README.md
+++ b/safir-arq/README.md
@@ -1,6 +1,6 @@
 # safir-arq
 
-safir-arq is a subpackage of Safir, Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Rubin Science Platform (Phalanx)](https://github.com/lsst-sqre/phalanx) and [Roundtable](https://github.com/lsst-sqre/roundtable) Kubernetes clusters.
+safir-arq is a subpackage of Safir, Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Phalanx](https://phalanx.lsst.io) Kubernetes clusters, including the Rubin Science Platform and Roundtable.
 It is a separate PyPI module so that it can be used as a dependency in contexts where the full Safir dependency is undesirable.
 
 safir-arq is available from [PyPI](https://pypi.org/project/safir-arq/):

--- a/safir-logging/README.md
+++ b/safir-logging/README.md
@@ -1,6 +1,6 @@
 # safir-logging
 
-safir-logging is a subpackage of Safir, Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Rubin Science Platform (Phalanx)](https://github.com/lsst-sqre/phalanx) and [Roundtable](https://github.com/lsst-sqre/roundtable) Kubernetes clusters.
+safir-logging is a subpackage of Safir, Rubin Observatory's library for building [FastAPI](https://fastapi.tiangolo.com/) services for the [Phalanx](https://phalanx.lsst.io) Kubernetes clusters, including the Rubin Science Platform and Roundtable.
 It is a separate PyPI module so that it can be used as a dependency in contexts where the full Safir dependency is undesirable.
 
 safir-logging is available from [PyPI](https://pypi.org/project/safir-logging/):


### PR DESCRIPTION
There are some steps users should take after creating a new project via Squarebot, so devote the main tutorial page to that and move the manual process into a separate page with some duplication of steps. Update both for the current templates (uv, Ruff instead of Black, new dependency management method).

Update the README files to point to Phalanx in general and list the Rubin Science Platform and Roundtable as separate cases. Drop the link to the old Roundtable site, since that's no longer useful to users.

Drop the list of Safir features from the README. It's out of date and largely duplicates the documentation, which is already linked from the README.