### PR TITLE
DM-51912: arq - metrics

### DIFF
--- a/changelog.d/20250729_181448_danfuchs_HEAD.md
+++ b/changelog.d/20250729_181448_danfuchs_HEAD.md
@@ -1,0 +1,13 @@
+### New features
+
+#### Generic Arq metrics
+
+You can now instrument your [arq](https://github.com/python-arq/arq) jobs to emit an `arq_job_run` app metric with a `queue` tag and a `time_in_queue` field. You can use this to help you decide if and when you need to add more workers.
+
+To enable this, you need to:
+
+* Add app metrics configuration to your app
+* Add `queue` to the list of fields in the Sasquatch app metrics configuration
+* Create a `safir.metrics.EventManager` and pass it to `safir.metrics.initialize_arq_metrics` in your `WorkerSettings.on_startup` function.
+* Generate an `on_job_start` function by passing a queue name to `safir.metrics.make_on_job_start`.
+  Make sure you shut this event manager down cleanly in your shutdown function.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -26,6 +26,7 @@
 .. _respx: https://lundberg.github.io/respx/
 .. _Roundtable: https://roundtable.lsst.io
 .. _Sasquatch: https://sasquatch.lsst.io
+.. _Sasquatch app metrics configuration: https://sasquatch.lsst.io/user-guide/app-metrics.html
 .. _schema registry: https://docs.confluent.io/platform/current/schema-registry/index.html
 .. _scriv: https://scriv.readthedocs.io/en/stable/
 .. _Sentry: https://sentry.io/welcome/

--- a/docs/user-guide/metrics/index.rst
+++ b/docs/user-guide/metrics/index.rst
@@ -55,6 +55,8 @@ For more details and examples of the difference between metrics and telemetery, 
 
 .. _Nublado: https://nublado.lsst.io
 
+.. _metrics-example:
+
 Full example
 ============
 
@@ -70,8 +72,6 @@ Sasquatch config
 ----------------
 
 Add your app to the `Sasquatch app metrics configuration`_!
-
-.. _Sasquatch app metrics configuration: https://sasquatch.lsst.io/user-guide/app-metrics.html
 
 Config
 ------

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -1,3 +1,10 @@
+from ._arq import (
+    ARQ_EVENTS_CONTEXT_KEY,
+    ArqEvents,
+    ArqQueueJobEvent,
+    initialize_arq_metrics,
+    make_on_job_start,
+)
 from ._config import (
     BaseMetricsConfiguration,
     DisabledMetricsConfiguration,
@@ -39,7 +46,10 @@ from ._testing import (
 
 __all__ = [
     "ANY",
+    "ARQ_EVENTS_CONTEXT_KEY",
     "NOT_NONE",
+    "ArqEvents",
+    "ArqQueueJobEvent",
     "BaseAssertionError",
     "BaseMetricsConfiguration",
     "DisabledMetricsConfiguration",
@@ -68,5 +78,7 @@ __all__ = [
     "PublishedList",
     "PublishedTooFewError",
     "UnsupportedAvroSchemaError",
+    "initialize_arq_metrics",
+    "make_on_job_start",
     "metrics_configuration_factory",
 ]

--- a/safir/src/safir/metrics/_arq.py
+++ b/safir/src/safir/metrics/_arq.py
@@ -1,0 +1,131 @@
+"""Tools for collecting generic metrics for Arq jobs and queues."""
+
+from datetime import datetime, timedelta
+from typing import Annotated, Any
+
+from arq.typing import StartupShutdown
+from pydantic import BaseModel, ConfigDict, Field
+
+from safir.datetime._current import current_datetime
+
+from ._event_manager import EventManager
+from ._models import EventPayload
+
+__all__ = [
+    "ARQ_EVENTS_CONTEXT_KEY",
+    "ArqMetricsError",
+    "ArqQueueJobEvent",
+    "initialize_arq_metrics",
+    "make_on_job_start",
+]
+
+
+ARQ_EVENTS_CONTEXT_KEY = "_arq_events"
+
+
+class ArqQueueJobEvent(EventPayload):
+    """Metrics for every job run by Arq."""
+
+    time_in_queue: timedelta
+    """Time between ideal job start and when it actually starts."""
+
+    queue: str
+    """The queue the job was picked from."""
+
+
+class ArqEvents:
+    """Container for Arq metrics event publishers."""
+
+    async def initialize(self, manager: EventManager) -> None:
+        """Create publishers for generic Arq events.
+
+        Parameters
+        ----------
+        manager
+            An initialized `safir.metrics.EventManager`
+        """
+        self.arq_queue_job_event = await manager.create_publisher(
+            "arq_job_run", ArqQueueJobEvent
+        )
+
+
+async def initialize_arq_metrics(
+    event_manager: EventManager, ctx: dict
+) -> None:
+    """Create Arq metrics publishers and inject them into the Arq context.
+
+    Parameters
+    ----------
+    event_manager
+        And initialized `safir.metrics.EventManager`
+
+    ctx
+        The context that gets passed to the on_startup function. This will be
+        mutated to add the ArqEvents instance.
+    """
+    events = ArqEvents()
+    await events.initialize(event_manager)
+    ctx[ARQ_EVENTS_CONTEXT_KEY] = events
+
+
+class ArqMetricsError(Exception):
+    """An exception from misuse/misconfiguration of Arq app metrics."""
+
+
+class ArqMetricsContext(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    events: Annotated[
+        ArqEvents, Field(validation_alias=ARQ_EVENTS_CONTEXT_KEY)
+    ]
+    """An object that contains Arq metrics events."""
+
+    # The score in the job context is the number of milliseconds since the
+    # epoch that this job would ideally start executing. Any difference
+    # between now (when is when the job actually starts executing) and this
+    # score is time waiting in the queue for other jobs to execute.
+    #
+    # Note there is also an enqueue_time item in the job context, and this
+    # is set to the time that the job was placed into the queue. We can't
+    # use this for defered jobs and crons becuase the time between then and
+    # now includes the time between when the job was enqueued and when we
+    # actually want it to run. Score is the time we actually want it to
+    # run.
+    ideal_start_time: Annotated[datetime, Field(validation_alias="score")]
+    """The time that this job should run."""
+
+
+def make_on_job_start(queue_name: str) -> StartupShutdown:
+    """Make a function that publishes an event for every job execution.
+
+    This should be set as, or composed with, your ``on_job_start`` function in
+    your Arq ``WorkerSettings`` class. You need to also call
+    `safir.metrics.initialize_arq_metrics` in your worker
+    ``on_startup`` function.
+
+    Parameters
+    ----------
+    queue_name
+        The name of the queue that this worker will be listening on.
+    """
+
+    async def on_job_start(ctx: dict[Any, Any]) -> Any:
+        try:
+            context = ArqMetricsContext(**ctx)
+        except Exception as e:
+            msg = (
+                "Arq context does not contain expected values. Make sure you "
+                "ran initialize_arq_metrics in your worker on_startup "
+                "function."
+            )
+            raise ArqMetricsError(msg) from e
+
+        time_in_queue = current_datetime() - context.ideal_start_time
+
+        event = ArqQueueJobEvent(
+            time_in_queue=time_in_queue,
+            queue=queue_name,
+        )
+        await context.events.arq_queue_job_event.publish(event)
+
+    return on_job_start

--- a/safir/tests/metrics/arq_metrics_test.py
+++ b/safir/tests/metrics/arq_metrics_test.py
@@ -1,0 +1,121 @@
+"""Tests for generic arq metrics functionality."""
+
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+from arq.connections import ArqRedis
+
+from safir.metrics import (
+    NOT_NONE,
+    EventsConfiguration,
+    MockEventPublisher,
+    MockMetricsConfiguration,
+)
+from safir.metrics._arq import (
+    ARQ_EVENTS_CONTEXT_KEY,
+    ArqEvents,
+    ArqMetricsError,
+    initialize_arq_metrics,
+    make_on_job_start,
+)
+
+
+async def somejob(_ctx: dict) -> int:
+    return 100
+
+
+@pytest.mark.asyncio
+async def test_arq_metrics(
+    arq_redis: ArqRedis,
+    create_arq_worker: Callable,
+) -> None:
+    # A variable to close over where we can put the container that
+    # initialize_arq_metrics injects into the context so that we can assert
+    # things about the events that were published
+    events: ArqEvents | None = None
+
+    # A startup function that initializes and event manager and calls
+    # initialize_arq_metrics
+    async def startup(ctx: dict) -> None:
+        nonlocal events
+        config = MockMetricsConfiguration(
+            application="testapp",
+            enabled=False,
+            events=EventsConfiguration(topic_prefix="what.ever"),
+            mock=True,
+        )
+        event_manager = config.make_manager()
+        await event_manager.initialize()
+
+        await initialize_arq_metrics(event_manager, ctx)
+        events = ctx[ARQ_EVENTS_CONTEXT_KEY]
+
+    # Create a real Arq worker
+    queue_name = "some_queue"
+    on_job_start = make_on_job_start(queue_name=queue_name)
+    worker = create_arq_worker(
+        functions=[somejob],
+        queue_name=queue_name,
+        on_startup=startup,
+        on_job_start=on_job_start,
+    )
+
+    # Enqueue a job
+    job = await arq_redis.enqueue_job("somejob", _queue_name=queue_name)
+    assert job
+
+    # Start the worker
+    await worker.main()
+    assert worker.jobs_complete == 1
+
+    # Make sure the with_arq_metrics decorator didn't ruin our result
+    result = await job.result()
+    assert result == 100
+
+    # Make sure the on_job_start function to published the right events
+    assert events is not None
+    publisher = cast("MockEventPublisher", events.arq_queue_job_event)
+    publisher.published.assert_published_all(
+        [
+            {
+                "time_in_queue": NOT_NONE,
+                "queue": queue_name,
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_arq_metrics_misconfiguration(
+    arq_redis: ArqRedis,
+    create_arq_worker: Callable,
+) -> None:
+    # A startup function that initializes and event manager but DOESN'T call
+    # initialize_arq_metrics
+    async def startup(ctx: dict) -> None:
+        config = MockMetricsConfiguration(
+            application="testapp",
+            enabled=False,
+            events=EventsConfiguration(topic_prefix="what.ever"),
+            mock=True,
+        )
+        event_manager = config.make_manager()
+        await event_manager.initialize()
+
+    # Create a real Arq worker
+    queue_name = "some_queue"
+    on_job_start = make_on_job_start(queue_name=queue_name)
+    worker = create_arq_worker(
+        functions=[somejob],
+        queue_name=queue_name,
+        on_startup=startup,
+        on_job_start=on_job_start,
+    )
+    # Enqueue a job
+    job = await arq_redis.enqueue_job("somejob", _queue_name=queue_name)
+    assert job
+
+    # Start the worker
+    with pytest.raises(ArqMetricsError):
+        await worker.main()


### PR DESCRIPTION
You can now instrument your [arq](https://github.com/python-arq/arq) jobs to emit an `arq_job_run` app metric with a `queue` tag and a `time_in_queue` field. You can use this to help you decide if and when you need to add more workers.

To enable this, you need to:

* Add app metrics configuration to your app
* Add `queue` to the list of fields in the Sasquatch app metrics configuration
* Create a `safir.metrics.EventManager` and pass it to `safir.metrics.initialize_arq_metrics` in your `WorkerSettings.on_startup` function.
* Generate an `on_job_start` function by passing a queue name to `safir.metrics.make_on_job_start`.
  Make sure you shut this event manager down cleanly in your shutdown function.

Using this in an app looks like [this PR](https://github.com/lsst-sqre/noteburst/pull/126/) for Noteburst.