### PR TITLE
DM-51984: Avoid get_container_host_ip for schema registry

### DIFF
--- a/changelog.d/20250728_103522_rra_DM_51984.md
+++ b/changelog.d/20250728_103522_rra_DM_51984.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Adjust `SchemaRegistryContainer` to work with the latest release of testcontainers. This may result in the wrong Confluent Schema Registry `host_name` setting if non-standard connection modes are used with that container.

--- a/safir/src/safir/testing/containers/_schema_registry.py
+++ b/safir/src/safir/testing/containers/_schema_registry.py
@@ -46,7 +46,7 @@ class SchemaRegistryContainer(DockerContainer):
         )
         self.with_env("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
         self.with_env(
-            "SCHEMA_REGISTRY_HOST_NAME", self.get_container_host_ip()
+            "SCHEMA_REGISTRY_HOST_NAME", self.get_docker_client().host()
         )
 
     def start(self, *args: list[Any], **kwargs: dict[str, Any]) -> Self:


### PR DESCRIPTION
The latest testcontainers no longer supports `get_container_host_ip` before the container has started, which broke the Safir support for standing up a Confluent Schema Registry test container. Switch to using `get_docker_client().host()`, which is what the previous method used except in the case of unusual network connection modes. This runs the risk that the other connection modes will not work, but hopefully that won't be a problem for our use cases.