### PR TITLE
DM-51984: Use stop instead of close for FastStream

### DIFF
--- a/changelog.d/20250728_114205_rra_DM_51984.md
+++ b/changelog.d/20250728_114205_rra_DM_51984.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Close FastStream brokers with `stop` instead of `close` and require FastStream 0.5.44 or later to avoid deprecation warnings.

--- a/docs/user-guide/kafka/testing.rst
+++ b/docs/user-guide/kafka/testing.rst
@@ -100,7 +100,7 @@ Typically, you will want to add some additional fixtures to get the Kafka connec
        )
        await broker.start()
        yield broker
-       await broker.close()
+       await broker.stop()
 
 
    @pytest_asyncio.fixture

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "cryptography<46",
     "dataclasses-avroschema>=0.65.7,<1",
     "fastapi>=0.100,<1",
-    "faststream>0.5,<0.6",
+    "faststream>=0.5.44,<0.6",
     "gidgethub<6",
     "httpx>=0.20.0,<1",
     "pydantic>2,<3",

--- a/safir/src/safir/metrics/_event_manager.py
+++ b/safir/src/safir/metrics/_event_manager.py
@@ -588,7 +588,7 @@ class KafkaEventManager(EventManager):
     async def aclose(self) -> None:
         """Clean up the Kafka clients if they are managed."""
         if self._manage_kafka_broker:
-            await self._broker.close()
+            await self._broker.stop()
         await self._admin_client.close()
         await super().aclose()
 

--- a/safir/tests/kafka/kafka_config_test.py
+++ b/safir/tests/kafka/kafka_config_test.py
@@ -41,7 +41,7 @@ async def assert_clients(settings: KafkaConnectionSettings) -> None:
         if consumer:
             await consumer.stop()
         if broker:
-            await broker.close()
+            await broker.stop()
 
 
 @pytest.mark.asyncio

--- a/safir/tests/support/kafka.py
+++ b/safir/tests/support/kafka.py
@@ -203,6 +203,6 @@ async def make_kafka_clients(
         if kafka_consumer:
             await kafka_consumer.stop()
         if kafka_broker:
-            await kafka_broker.close()
+            await kafka_broker.stop()
         if kafka_admin_client:
             await kafka_admin_client.close()


### PR DESCRIPTION
Close FastStream brokers with `stop` instead of `close` and require FastStream 0.5.44 or later to avoid deprecation warnings.