### PR TITLE
metrics - fix arq time-in-queue metric

### DIFF
--- a/changelog.d/20250805_150146_danfuchs_HEAD.md
+++ b/changelog.d/20250805_150146_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- metrics: calculate arq time-in-queue value with millisecond precision. This prevents inaccurate and negative values.

--- a/safir/src/safir/metrics/_arq.py
+++ b/safir/src/safir/metrics/_arq.py
@@ -136,7 +136,8 @@ def make_on_job_start(queue_name: str) -> StartupShutdown:
             )
             raise ArqMetricsError(msg) from e
 
-        time_in_queue = current_datetime() - context.ideal_start_time
+        now = current_datetime(microseconds=True)
+        time_in_queue = now - context.ideal_start_time
 
         event = ArqQueueJobEvent(
             time_in_queue=time_in_queue,


### PR DESCRIPTION
The arq time-in-queue metric is comparing the current time at whole second precision, with the arq enqueued time at millisecond precision, resulting in negative values.

Fix this by not truncating the current time when calculating the value.