### PR TITLE
DM-52090: metrics - fix arq import

### DIFF
--- a/changelog.d/20250806_154447_danfuchs_HEAD.md
+++ b/changelog.d/20250806_154447_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Move arq metrics helpers out of `safir.metrics`, to the separately importable `safir.metrics.arq`. This avoids the `safir` package depending on the `arq` package, which is only installed with the `safir[arq]` extra.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,6 +72,9 @@ API reference
 .. automodapi:: safir.metrics
    :include-all-objects:
 
+.. automodapi:: safir.metrics.arq
+   :include-all-objects:
+
 .. automodapi:: safir.models
    :include-all-objects:
 

--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -266,7 +266,7 @@ Some metrics are emitted for every job, and some should be emitted periodically.
 
 Per-job metrics
 ---------------
-You can emit a `safir.metrics.ArqQueueJobEvent` every time arq executes one of your job functions.
+You can emit a `safir.metrics.arq.ArqQueueJobEvent` every time arq executes one of your job functions.
 This event contains a ``time_in_queue`` field which is, for a given queue, the difference between when arq would ideally start executing a job, and when it actually does.
 This is useful for deciding if you need more workers processing jobs from that queue.
 
@@ -274,8 +274,8 @@ To enable this, you need to:
 
 * Add app metrics configuration to your app, as in :ref:`metrics-example`
 * Add ``queue`` to the list of fields in the `Sasquatch app metrics configuration`_
-* Create a `safir.metrics.EventManager` and pass it to `safir.metrics.initialize_arq_metrics` in your ``WorkerSettings.on_startup`` function.
-* Generate an ``on_job_start`` function by passing a queue name to `safir.metrics.make_on_job_start`.
+* Create a `safir.metrics.EventManager` and pass it to `safir.metrics.arq.initialize_arq_metrics` in your ``WorkerSettings.on_startup`` function.
+* Generate an ``on_job_start`` function by passing a queue name to `safir.metrics.arq.make_on_job_start`.
   Make sure you shut this event manager down cleanly in your shutdown function.
 
 Your worker set up in :file:`worker/main.py` might look like this:
@@ -291,7 +291,7 @@ Your worker set up in :file:`worker/main.py` might look like this:
     import httpx
     import structlog
     from safir.logging import configure_logging
-    from safir.metrics import initialize_arq_metrics, make_on_job_start
+    from safir.metrics.arq import initialize_arq_metrics, make_on_job_start
 
     from ..config import config
     from .functions import function_a, function_b
@@ -364,7 +364,7 @@ Your worker set up in :file:`worker/main.py` might look like this:
 Periodic metrics
 ----------------
 
-You can use `safir.metrics.publish_queue_stats` to publish a `safir.metrics.ArqQueueStatsEvent`.
+You can use `safir.metrics.arq.publish_queue_stats` to publish a `safir.metrics.arq.ArqQueueStatsEvent`.
 This queries Redis to get information about a given Arq queue.
 It should be called periodically.
 
@@ -377,7 +377,7 @@ You could have a file in your app, maybe :file:``periodic_metrics.py``, that loo
 
    import asyncio
 
-   from safir.metrics import ArqEvents, publish_queue_stats
+   from safir.metrics.arq import ArqEvents, publish_queue_stats
 
    from .config import config
 

--- a/safir/src/safir/metrics/__init__.py
+++ b/safir/src/safir/metrics/__init__.py
@@ -1,12 +1,3 @@
-from ._arq import (
-    ARQ_EVENTS_CONTEXT_KEY,
-    ArqEvents,
-    ArqQueueJobEvent,
-    ArqQueueStatsEvent,
-    initialize_arq_metrics,
-    make_on_job_start,
-    publish_queue_stats,
-)
 from ._config import (
     BaseMetricsConfiguration,
     DisabledMetricsConfiguration,
@@ -48,11 +39,7 @@ from ._testing import (
 
 __all__ = [
     "ANY",
-    "ARQ_EVENTS_CONTEXT_KEY",
     "NOT_NONE",
-    "ArqEvents",
-    "ArqQueueJobEvent",
-    "ArqQueueStatsEvent",
     "BaseAssertionError",
     "BaseMetricsConfiguration",
     "DisabledMetricsConfiguration",
@@ -81,8 +68,5 @@ __all__ = [
     "PublishedList",
     "PublishedTooFewError",
     "UnsupportedAvroSchemaError",
-    "initialize_arq_metrics",
-    "make_on_job_start",
     "metrics_configuration_factory",
-    "publish_queue_stats",
 ]

--- a/safir/src/safir/metrics/arq.py
+++ b/safir/src/safir/metrics/arq.py
@@ -1,10 +1,21 @@
-"""Tools for collecting generic metrics for Arq jobs and queues."""
+"""Tools for collecting generic metrics for Arq jobs and queues.
+
+This module is importable separately from the rest of the metrics package
+because it depends on the ``arq`` package, which is only installed with the
+optional ``safir[arq]`` extra.
+"""
 
 from datetime import datetime, timedelta
 from typing import Annotated, Any
 
-from arq.connections import RedisSettings, create_pool
-from arq.typing import StartupShutdown
+try:
+    from arq.connections import RedisSettings, create_pool
+    from arq.typing import StartupShutdown
+except ImportError as e:
+    raise ImportError(
+        "The safir.metrics.arq module requires the arq extra. "
+        "Install it with `pip install safir[arq]`."
+    ) from e
 from pydantic import BaseModel, ConfigDict, Field
 
 from safir.datetime._current import current_datetime
@@ -14,6 +25,7 @@ from ._models import EventPayload
 
 __all__ = [
     "ARQ_EVENTS_CONTEXT_KEY",
+    "ArqEvents",
     "ArqMetricsError",
     "ArqQueueJobEvent",
     "ArqQueueStatsEvent",
@@ -116,7 +128,7 @@ def make_on_job_start(queue_name: str) -> StartupShutdown:
 
     This should be set as, or composed with, your ``on_job_start`` function in
     your Arq ``WorkerSettings`` class. You need to also call
-    `safir.metrics.initialize_arq_metrics` in your worker
+    `safir.metrics.arq.initialize_arq_metrics` in your worker
     ``on_startup`` function.
 
     Parameters
@@ -161,7 +173,6 @@ async def publish_queue_stats(
         The name of the Arq queue.
     redis_settings
         Connection info for the redis instance containing the queue.
-
     arq_events
         A collection of Arq metrics event publishers.
     """

--- a/safir/tests/metrics/arq_metrics_test.py
+++ b/safir/tests/metrics/arq_metrics_test.py
@@ -12,7 +12,7 @@ from safir.metrics import (
     MockEventPublisher,
     MockMetricsConfiguration,
 )
-from safir.metrics._arq import (
+from safir.metrics.arq import (
     ARQ_EVENTS_CONTEXT_KEY,
     ArqEvents,
     ArqMetricsError,


### PR DESCRIPTION
Move arq metrics helpers out of `safir.metrics`, to the separately importable `safir.metrics.arq`. This avoids the `safir` package depending on the `arq` package, which is only installed with the `safir[arq]` extra.