### PR TITLE
DM-52238: Add lower bounds on Google modules

### DIFF
--- a/changelog.d/20250821_164709_rra_DM_52238a.md
+++ b/changelog.d/20250821_164709_rra_DM_52238a.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add lower version bounds on the google-auth and google-cloud-storage dependencies so that dependency resolvers will not downgrade them to ancient versions in order to upgrade cachetools.

--- a/safir/pyproject.toml
+++ b/safir/pyproject.toml
@@ -70,8 +70,8 @@ dev = [
     "autodoc_pydantic",
 ]
 gcs = [
-    "google-auth<3",
-    "google-cloud-storage<4"
+    "google-auth>2,<3",
+    "google-cloud-storage>3,<4"
 ]
 kubernetes = [
     "kubernetes_asyncio<34"
@@ -83,8 +83,8 @@ testcontainers = [
     "testcontainers>=4.10"
 ]
 uws = [
-    "google-auth<3",
-    "google-cloud-storage<4",
+    "google-auth>2,<3",
+    "google-cloud-storage>3,<4",
     "jinja2<4",
     "python-multipart",
     "safir-arq>10.2.0",


### PR DESCRIPTION
Updating dependencies on vo-cutouts tried to downgrade the Google API modules to an ancient version because they pin an older major version of cachetools and the latest version of tox depends on the new version. Ensure this cannot happen by setting a version floor for the Google API modules.