### PR TITLE
Remove `id` field from app metrics events

### DIFF
--- a/changelog.d/20250822_124349_danfuchs_HEAD.md
+++ b/changelog.d/20250822_124349_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- App metrics events no longer have an `id` field. This field was originally going to be used for replay and deduplication of app metrics events, but we're not going to implement any of that. It now has no use and just takes up space in InfluxDB.

--- a/safir/src/safir/metrics/_event_manager.py
+++ b/safir/src/safir/metrics/_event_manager.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum, auto
 from typing import Concatenate, cast, override
-from uuid import uuid4
 
 import structlog
 from aiokafka.admin.client import AIOKafkaAdminClient
@@ -163,7 +162,6 @@ class EventPublisher[P: EventPayload](metaclass=ABCMeta):
         """
         time_ns = time.time_ns()
         metadata = EventMetadata(
-            id=uuid4(),
             application=self._application,
             timestamp=self._ns_to_datetime(time_ns),
             timestamp_ns=time_ns,

--- a/safir/src/safir/metrics/_models.py
+++ b/safir/src/safir/metrics/_models.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from dataclasses_avroschema.pydantic import AvroBaseModel
-from pydantic import UUID4, AwareDatetime, Field, create_model
+from pydantic import AwareDatetime, Field, create_model
 
 from safir.metrics._exceptions import UnsupportedAvroSchemaError
 
@@ -17,11 +17,6 @@ class EventMetadata(AvroBaseModel):
     to a class also containing event payload fields, and
     then gets shipped to Kafka, by the ``EventManager``
     """
-
-    id: UUID4 = Field(
-        title="id",
-        description="A globally unique value that identifies this event",
-    )
 
     application: str = Field(
         description="The application generating this event.",

--- a/safir/tests/metrics/event_manager_test.py
+++ b/safir/tests/metrics/event_manager_test.py
@@ -7,7 +7,6 @@ import math
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import cast
-from uuid import UUID
 
 import pytest
 from aiokafka import AIOKafkaConsumer, TopicPartition
@@ -91,7 +90,6 @@ async def assert_from_kafka(
     deserialized = event_class(**deserialized_dict)
 
     assert isinstance(deserialized, EventMetadata)
-    assert isinstance(deserialized.id, UUID)
     assert deserialized.application == "testapp"
 
     # dataclasses-avroschema serializes python datetime's into avro


### PR DESCRIPTION
This field was originally going to be used for replay and deduplication of app metrics events, but we're not going to implement any of that. It now has no use and just takes up space in InfluxDB.