### PR TITLE
DM-53491: Add change log for kafka extra change

### DIFF
--- a/changelog.d/20250911_115737_rra_DM_53491.md
+++ b/changelog.d/20250911_115737_rra_DM_53491.md
@@ -1,0 +1,7 @@
+### Backwards-incompatible changes
+
+- Move Kafka dependencies to an extra. Users of safir.kafka or safir.metrics must now depend on `safir[kafka]`.
+
+### Bug fixes
+
+- Catch import errors in Safir modules that depend on extra dependencies and report a custom error indicating which extra dependency is required.


### PR DESCRIPTION
Add the forgotten change log entry for the move of Kafka dependencies to a kafka extra.