### PR TITLE
DM-52550: Fix Starlette deprecation warning

### DIFF
--- a/changelog.d/20250917_101610_danfuchs_HEAD.md
+++ b/changelog.d/20250917_101610_danfuchs_HEAD.md
@@ -1,0 +1,12 @@
+### Other changes
+
+- Starlette deprecated the `HTTP_422_UNPROCESSABLE_ENTITY` constant and
+  changed it to `HTTP_422_UNPROCESSABLE_CONTENT` in [this
+  PR](https://github.com/Kludex/starlette/pull/2939). We could either
+  change this constant in our code, or just use the status code int
+  directly.
+
+  Use status code directly here rather than the new constant in
+  to avoid having to increase the lower bound on starlette. This is the
+  choice that the FastAPI folks made in [this
+  PR](https://github.com/fastapi/fastapi/pull/14077/files).

--- a/src/safir/fastapi/_errors.py
+++ b/src/safir/fastapi/_errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from fastapi import Request, status
+from fastapi import Request
 from fastapi.responses import JSONResponse
 
 from safir.models import ErrorLocation
@@ -133,7 +133,13 @@ class ClientRequestError(SlackIgnoredException):
     Should be overridden by any subclass.
     """
 
-    status_code: ClassVar[int] = status.HTTP_422_UNPROCESSABLE_ENTITY
+    # We use the status code directly here rather than the constant in
+    # fastapi.status to avoid having to increase the lower bound on starlette,
+    # which changed the attribute name for the 422 status:
+    #
+    # https://github.com/Kludex/starlette/pull/2939
+    # https://github.com/fastapi/fastapi/pull/14077/files
+    status_code: ClassVar[int] = 422
     """HTTP status code for this type of validation error."""
 
     def __init__(


### PR DESCRIPTION
```.tox/py/lib/python3.13/site-packages/safir/fastapi/_errors.py:19
  /home/danfuchs/src/noteburst/.tox/py/lib/python3.13/site-packages/safir/fastapi/_errors.py:19: DeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
    class ClientRequestError(SlackIgnoredException):
```
Starlette deprecated the `HTTP_422_UNPROCESSABLE_ENTITY` constant and changed it to `HTTP_422_UNPROCESSABLE_CONTENT` in [this PR](https://github.com/Kludex/starlette/pull/2939). We could either change this constant in our code, or just use the status code int directly.

This PR uses status code directly here rather than the new constant in to avoid having to increase the lower bound on starlette. This is the choice that the FastAPI folks made in [this
PR](https://github.com/fastapi/fastapi/pull/14077/files).