### PR TITLE
Fix initialize_sentry typing

### DIFF
--- a/changelog.d/20250922_164003_danfuchs_HEAD.md
+++ b/changelog.d/20250922_164003_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- `safir.sentry.initialize_sentry` now has the correct (though unfortunate) type of `Any` for `**additional_kwargs`

--- a/src/safir/sentry/_config.py
+++ b/src/safir/sentry/_config.py
@@ -59,9 +59,7 @@ def should_enable_sentry() -> bool:
     return bool(os.environ.get("SENTRY_DSN"))
 
 
-def initialize_sentry(
-    release: str, **additional_kwargs: dict[str, Any]
-) -> None:
+def initialize_sentry(release: str, **additional_kwargs: Any) -> None:
     """Initialize Sentry with env var values and the safir before_send handler.
 
     Most Safir apps should provide certain Sentry parameters. This method will
@@ -82,5 +80,9 @@ def initialize_sentry(
 
     config = SentryConfig()
     kwargs = config.model_dump()
-    kwargs.update(**additional_kwargs)
-    sentry_sdk.init(before_send=before_send_handler, release=release, **kwargs)
+    sentry_sdk.init(
+        before_send=before_send_handler,
+        release=release,
+        **kwargs,
+        **additional_kwargs,
+    )


### PR DESCRIPTION
The type in `**kwargs: <type>` is the type of one of the values, not of the kwargs dict :facepalm: Someday I will retain this fact.

In the meantime, I don't think there is any way to keep the type info of the params to `sentry_sdk.init`. There is a way to keep type info from a wrapped function's params, and info from a wrapped function's params plus additional  positional args, but no way to keep info from a wrapped function's params _minus_ some kw params:

https://peps.python.org/pep-0612/#concatenating-keyword-parameters