### PR TITLE
DM-54113: Fix AsyncMultiQueue exception message

### DIFF
--- a/src/safir/asyncio/_multiqueue.py
+++ b/src/safir/asyncio/_multiqueue.py
@@ -163,7 +163,7 @@ class AsyncMultiQueue[T]:
             call to `clear`.
         """
         if self.finished:
-            msg = "end was already called, must call clear before put"
+            msg = "close was already called, must call clear before put"
             raise AsyncMultiQueueError(msg)
         self._contents.append(item)
         for trigger in self._triggers:


### PR DESCRIPTION
The text of the `AsyncMultiQueueError` exception referred to the wrong method. Use the current method name.