### PR TITLE
DM-54944: Add aclose method to arq queues

### DIFF
--- a/changelog.d/20260513_162751_rra_DM_54944.md
+++ b/changelog.d/20260513_162751_rra_DM_54944.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add an `aclose` method to `ArqQueue` and `arq_dependency` so that users of arq support can cleanly shut down the underlying Redis pool.

--- a/docs/user-guide/arq.rst
+++ b/docs/user-guide/arq.rst
@@ -39,6 +39,7 @@ In your application's FastAPI setup module, typically :file:`main.py`, you need 
             mode=config.arq_mode, redis_settings=config.arq_redis_settings
         )
         yield
+        await arq_dependency.aclose()
 
 
     app = FastAPI(lifespan=lifespan)
@@ -264,6 +265,7 @@ Some metrics are emitted for every job, and some should be emitted periodically.
 
 Per-job metrics
 ---------------
+
 You can emit a `safir.metrics.arq.ArqQueueJobEvent` every time arq executes one of your job functions.
 This event contains a ``time_in_queue`` field which is, for a given queue, the difference between when arq would ideally start executing a job, and when it actually does.
 This is useful for deciding if you need more workers processing jobs from that queue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 arq = [
-    "safir-arq>10.2.0",
+    "safir-arq>15.0.0",
 ]
 db = [
     "alembic[tz]<2",

--- a/safir-arq/src/safir/arq/_queue.py
+++ b/safir-arq/src/safir/arq/_queue.py
@@ -158,6 +158,14 @@ class ArqQueue(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    async def aclose(self) -> None:
+        """Shut down the queue and free any underlying resources.
+
+        The object must not be used after this method is called.
+        """
+        raise NotImplementedError
+
 
 class RedisArqQueue(ArqQueue):
     """A distributed queue, based on arq and Redis."""
@@ -236,6 +244,10 @@ class RedisArqQueue(ArqQueue):
     ) -> JobResult:
         job = self._get_job(job_id, queue_name=queue_name)
         return await JobResult.from_job(job)
+
+    @override
+    async def aclose(self) -> None:
+        await self._pool.aclose()
 
 
 class MockArqQueue(ArqQueue):
@@ -378,3 +390,7 @@ class MockArqQueue(ArqQueue):
             queue_name=queue_name,
         )
         self._job_results[queue_name][job_id] = result_info
+
+    @override
+    async def aclose(self) -> None:
+        pass

--- a/src/safir/dependencies/arq.py
+++ b/src/safir/dependencies/arq.py
@@ -84,6 +84,16 @@ class ArqDependency:
             raise RuntimeError("ArqDependency is not initialized")
         return self._arq_queue
 
+    async def aclose(self) -> None:
+        """Shut down the underlying arq queue.
+
+        After this method is called, `initialize` must be called again before
+        the dependency can be used.
+        """
+        if self._arq_queue is not None:
+            await self._arq_queue.aclose()
+            self._arq_queue = None
+
 
 arq_dependency = ArqDependency()
 """Singleton instance of `ArqDependency` that serves as a FastAPI

--- a/tests/dependencies/arq_test.py
+++ b/tests/dependencies/arq_test.py
@@ -18,6 +18,7 @@ from safir.dependencies.arq import arq_dependency
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await arq_dependency.initialize(mode=ArqMode.test, redis_settings=None)
     yield
+    await arq_dependency.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add an `aclose` method to `ArqQueue` and `arq_dependency` so that users of arq support can cleanly shut down the underlying Redis pool.

Closes #522