### PR TITLE
DM-54944: Harden handling of X-Forwarded-For headers

### DIFF
--- a/changelog.d/20260513_170554_rra_DM_54944.md
+++ b/changelog.d/20260513_170554_rra_DM_54944.md
@@ -1,0 +1,7 @@
+### New features
+
+- Handle multiple `X-Forwarded-For` headers in `XForwardedMiddleware` in the way documented by MDN by combining their values in order.
+
+### Bug fixes
+
+- Ignore malformed `X-Forwarded-For` header entries in `XForwardedMiddleware` instead of raising uncaught `ValueError` exceptions.

--- a/src/safir/middleware/x_forwarded.py
+++ b/src/safir/middleware/x_forwarded.py
@@ -1,7 +1,7 @@
 """Update the request based on ``X-Forwarded-For`` headers."""
 
 from copy import copy
-from ipaddress import _BaseAddress, _BaseNetwork, ip_address
+from ipaddress import IPv4Address, IPv6Address, _BaseNetwork, ip_address
 
 from starlette.datastructures import Headers
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -13,14 +13,13 @@ class XForwardedMiddleware:
     """ASGI middleware to update the request based on ``X-Forwarded-For``.
 
     The remote IP address will be replaced with the right-most IP address in
-    ``X-Forwarded-For`` that is not contained within one of the trusted
-    proxy networks.
+    ``X-Forwarded-For`` that is not contained within one of the trusted proxy
+    networks.
 
     If ``X-Forwarded-For`` is found and ``X-Forwarded-Proto`` is also present,
-    the corresponding entry of ``X-Forwarded-Proto`` is used to replace the
-    scheme in the request scope. If ``X-Forwarded-Proto`` only has one entry
-    (ingress-nginx has this behavior), that one entry will become the new
-    scheme in the request scope.
+    ``X-Forwarded-Proto`` is used to replace the scheme in the request scope.
+    If ``X-Forwarded-Proto`` only has one entry (ingress-nginx has this
+    behavior), that one entry will become the new scheme in the request scope.
 
     The contents of ``X-Forwarded-Host`` will be stored as ``forwarded_host``
     in the request state if it and ``X-Forwarded-For`` are present. Normally
@@ -93,29 +92,35 @@ class XForwardedMiddleware:
         await self._app(scope, receive, send)
         return
 
-    def _get_forwarded_for(self, headers: Headers) -> list[_BaseAddress]:
+    def _get_forwarded_for(
+        self, headers: Headers
+    ) -> list[IPv4Address | IPv6Address]:
         """Retrieve the ``X-Forwarded-For`` entries from the request.
 
         Parameters
         ----------
-        scope
+        headers
             Request headers.
 
         Returns
         -------
         list of ipaddress._BaseAddress
             The list of addresses found in the header. If there are multiple
-            ``X-Forwarded-For`` headers, we don't know which one is correct,
-            so act as if there are no headers.
+            ``X-Forwarded-For`` headers, process them in the order seen.
         """
-        forwarded_for_str = headers.getlist("X-Forwarded-For")
-        if not forwarded_for_str or len(forwarded_for_str) > 1:
-            return []
-        return [
-            ip_address(addr)
-            for addr in (a.strip() for a in forwarded_for_str[0].split(","))
-            if addr
-        ]
+        forwarded_for_headers = headers.getlist("X-Forwarded-For")
+        forwarded_for = []
+        for header in forwarded_for_headers:
+            for entry in header.split(","):
+                entry_stripped = entry.strip()
+                if not entry_stripped:
+                    continue
+                try:
+                    addr = ip_address(entry_stripped)
+                except ValueError:
+                    continue
+                forwarded_for.append(addr)
+        return forwarded_for
 
     def _get_forwarded_host(self, headers: Headers) -> str | None:
         """Retrieve the ``X-Forwarded-Host`` header.

--- a/tests/middleware/x_forwarded_test.py
+++ b/tests/middleware/x_forwarded_test.py
@@ -5,7 +5,6 @@ from ipaddress import _BaseNetwork, ip_network
 import pytest
 from fastapi import FastAPI, Request
 from httpx import ASGITransport, AsyncClient
-from starlette.datastructures import Headers
 
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
@@ -164,26 +163,115 @@ async def test_no_proto_or_host() -> None:
 
 @pytest.mark.asyncio
 async def test_too_many_headers() -> None:
-    """Test handling of duplicate headers.
+    """Test handling of duplicate headers."""
+    app = build_app([ip_network("10.0.0.0/8")])
 
-    HTTPX doesn't allow passing in duplicate headers, so we cannot test end to
-    end.  Instead, test by generating a mock request and then calling the
-    underling middleware functions directly.
+    @app.get("/")
+    async def handler(request: Request) -> dict[str, str]:
+        assert request.client
+        assert request.client.host == "1.1.1.1"
+        assert not request.state.forwarded_host
+        assert request.url == "http://example.com/"
+        return {}
+
+    transport = ASGITransport(app=app)
+    base_url = "http://example.com"
+    async with AsyncClient(transport=transport, base_url=base_url) as client:
+        r = await client.get(
+            "/",
+            headers=[
+                ("X-Forwarded-For", "1.1.1.1"),
+                ("X-Forwarded-Proto", "http"),
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Host", "example.com"),
+                ("X-Forwarded-Host", "example.org"),
+            ],
+        )
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_multiple_headers() -> None:
+    """Test handling of multiple ``X-Forwarded-For`` headers.
+
+    The informal standard requires these be combined as if their contents were
+    all in one header separated by commas.
     """
-    scope = {
-        "type": "http",
-        "headers": [
-            ("X-Forwarded-For", "10.10.10.10"),
-            ("X-Forwarded-For", "10.10.10.1"),
-            ("X-Forwarded-Proto", "https"),
-            ("X-Forwarded-Proto", "http"),
-            ("X-Forwarded-Host", "example.org"),
-            ("X-Forwarded-Host", "example.com"),
-        ],
-    }
-    headers = Headers(scope=scope)
-    app = FastAPI()
-    middleware = XForwardedMiddleware(app, proxies=[ip_network("10.0.0.0/8")])
-    assert middleware._get_forwarded_for(headers) == []
-    assert middleware._get_forwarded_proto(headers) == []
-    assert not middleware._get_forwarded_host(headers)
+    app = build_app([ip_network("10.0.0.0/8")])
+
+    @app.get("/")
+    async def handler(request: Request) -> dict[str, str]:
+        assert request.client
+        assert request.client.host == "1.1.1.1"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "https://example.com/"
+        return {}
+
+    transport = ASGITransport(app=app)
+    base_url = "http://example.com"
+    async with AsyncClient(transport=transport, base_url=base_url) as client:
+        r = await client.get(
+            "/",
+            headers=(
+                ("X-Forwarded-For", "1.1.1.1"),
+                ("X-Forwarded-For", "10.10.10.10"),
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Host", "foo.example.com"),
+            ),
+        )
+        assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_malformed() -> None:
+    app = build_app([ip_network("10.0.0.0/8")])
+
+    @app.get("/")
+    async def handler(request: Request) -> dict[str, str]:
+        assert request.client
+        assert request.client.host == "2.2.2.2"
+        assert request.state.forwarded_host == "foo.example.com"
+        assert request.url == "https://foo.example.com/"
+        return {}
+
+    transport = ASGITransport(app=app)
+    base_url = "http://example.com"
+    async with AsyncClient(transport=transport, base_url=base_url) as client:
+        r = await client.get(
+            "/",
+            headers=(
+                ("Host", "foo.example.com"),
+                ("X-Forwarded-For", "'1.1.1.1'"),
+                ("X-Forwarded-For", "2.2.2.2"),
+                ("X-Forwarded-For", "10.0.0.1"),
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Host", "foo.example.com"),
+            ),
+        )
+        assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_malformed_only() -> None:
+    app = build_app([ip_network("10.0.0.0/8")])
+
+    @app.get("/")
+    async def handler(request: Request) -> dict[str, str]:
+        assert request.client
+        assert request.client.host == "127.0.0.1"
+        assert request.state.forwarded_host is None
+        assert request.url == "http://example.com/"
+        return {}
+
+    transport = ASGITransport(app=app)
+    base_url = "http://example.com"
+    async with AsyncClient(transport=transport, base_url=base_url) as client:
+        r = await client.get(
+            "/",
+            headers={
+                "X-Forwarded-For": "'1.1.1.1'",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "foo.example.com",
+            },
+        )
+        assert r.status_code == 200


### PR DESCRIPTION
MDN says that multiple `X-Forwarded-For` headers should be parsed by concatenating their contents, so add support for that. Rewrite the tests for duplicate headers to use HTTPX properly. Add handling of malformed `X-Forwarded-For` entries by ignoring them rather than raising an uncaught `ValueError`.