### PR TITLE
DM-55193: Remove extra space in DuplicateEventError message

### DIFF
--- a/src/safir/metrics/_exceptions.py
+++ b/src/safir/metrics/_exceptions.py
@@ -31,8 +31,8 @@ class DuplicateEventError(EventManagerUsageError):
 
     def __init__(self, name: str) -> None:
         super().__init__(
-            f"{name}: you have already created an event with this "
-            " name. Events must have unique names within this "
+            f"{name}: you have already created an event with this"
+            " name. Events must have unique names within this"
             " application."
         )
 


### PR DESCRIPTION
The extended `DuplicateEventError` exception message had doubled spaces where it was folded in the source code. Remove the extra spaces.