### PR TITLE
DM-55358: Fix HTTP status code for UWS sync usage errors

### DIFF
--- a/changelog.d/20260702_171315_rra_DM_55358.md
+++ b/changelog.d/20260702_171315_rra_DM_55358.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- In the UWS support code, return 422 from the sync handler on backend usage errors instead of 500.

--- a/src/safir/uws/_exceptions.py
+++ b/src/safir/uws/_exceptions.py
@@ -73,7 +73,10 @@ class SyncJobFailedError(UWSError):
 
     def __init__(self, error: JobError) -> None:
         super().__init__(error.code, error.message, error.detail)
-        self.status_code = 500
+        if error.code == "UsageError":
+            self.status_code = 422
+        else:
+            self.status_code = 500
 
 
 class SyncJobNoResultsError(UWSError):

--- a/tests/uws/job_sync_test.py
+++ b/tests/uws/job_sync_test.py
@@ -1,0 +1,67 @@
+"""Test synchronous UWS job execution."""
+
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+from safir.arq.uws import WorkerResult, WorkerUsageError
+from safir.testing.uws import MockUWSJobRunner
+from safir.uws._exceptions import TaskError
+
+
+@pytest.mark.asyncio
+async def test_sync(
+    client: AsyncClient,
+    test_token: str,
+    runner: MockUWSJobRunner,
+) -> None:
+    results = [
+        WorkerResult(
+            result_id="cutout",
+            url="s3://some-bucket/some/path",
+            mime_type="application/fits",
+        )
+    ]
+
+    # Start sync POST and GET requests.
+    task_post = asyncio.create_task(
+        client.post("/test/sync", data={"name": "Jane"})
+    )
+    task_get = asyncio.create_task(
+        client.get("/test/sync", params={"name": "Jane"})
+    )
+    await asyncio.sleep(0.1)
+
+    # Tell the queue the jobs are finished.
+    for job_id in ("1", "2"):
+        await runner.mark_complete(test_token, job_id, results)
+
+    # The sync request tasks should now return a redirect response to the
+    # proper fake signed URL.
+    for task in (task_post, task_get):
+        r = await task
+        assert r.status_code == 303
+        assert r.headers["Location"] == "https://example.com/some/path"
+
+
+@pytest.mark.asyncio
+async def test_sync_usage_error(
+    client: AsyncClient,
+    test_token: str,
+    runner: MockUWSJobRunner,
+) -> None:
+    task = asyncio.create_task(
+        client.post("/test/sync", data={"name": "Jane"})
+    )
+    await asyncio.sleep(0.1)
+
+    # Register a failure with a usage error.
+    exc = WorkerUsageError("Some usage error")
+    result = TaskError.from_worker_error(exc)
+    await runner.mark_complete(test_token, "1", result)
+
+    # This should return a 422 error with the correct body.
+    r = await task
+    assert r.text == "UsageError: Some usage error\n"
+    assert r.status_code == 422


### PR DESCRIPTION
Return an HTTP status code of 422 instead of 500 for usage errors reported by the backend, since this represents a client error.

Add some tests for UWS sync route handling, which appears to have not previously been tested.