### PR TITLE
DM-55366: Support pessimistic database connection handling

### DIFF
--- a/changelog.d/20260706_143253_rra_DM_55366.md
+++ b/changelog.d/20260706_143253_rra_DM_55366.md
@@ -1,0 +1,4 @@
+### New features
+
+- Add `pool_pre_ping` and `pool_recycle` to `create_database_engine` and `db_session_dependency` with the same meanings as in SQLAlchemy. Recommend setting `pool_pre_ping=True` in applications that only use the database intermittently.
+- Add `InterfaceError` to the exceptions caught and retried by `@retry_async_transaction` so that this decorator can also be used to protect against database connection drops.

--- a/docs/user-guide/database/dependency.rst
+++ b/docs/user-guide/database/dependency.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: safir.dependencies.db_session
+
 ############################################
 Using a database session in request handlers
 ############################################
@@ -33,14 +35,15 @@ You must also close the dependency during application shutdown.
 
    app = FastAPI(lifespan=lifespan)
 
-`~safir.dependencies.db_session.DatabaseSessionDependency.initialize` takes the same optional parameters as `~safir.database.create_database_engine`.
+`DatabaseSessionDependency.initialize` takes the same optional parameters as `~safir.database.create_database_engine`.
+See :ref:`db-engine-parameters` for more details.
 
 As with some of the examples above, this assumes the application has a ``config`` object with the application settings, including the database URL and password.
 
 Using the dependency
 ====================
 
-Any handler that needs a database session can depend on the `~safir.dependencies.db_session.db_session_dependency`:
+Any handler that needs a database session can depend on `db_session_dependency`:
 
 .. code-block:: python
 

--- a/docs/user-guide/database/retry.rst
+++ b/docs/user-guide/database/retry.rst
@@ -1,9 +1,11 @@
+.. py:currentmodule:: safir.database
+
 ##############################
 Retrying database transactions
 ##############################
 
-To aid in retrying transactions, Safir provides a decorator function, `safir.database.retry_async_transaction`.
-Retrying transactions is often useful in conjunction with a custom transaction isolation level.
+To aid in retrying transactions, Safir provides a decorator function, `retry_async_transaction`.
+Retrying transactions provides more robustness against database connection drops, and is also useful in conjunction with a custom transaction isolation level.
 
 Setting an isolation level
 ==========================
@@ -11,7 +13,7 @@ Setting an isolation level
 If you have multiple simultaneous database writers and need to coordinate their writes to ensure consistent results, you may have to set a custom isolation level, such as ``REPEATABLE READ``,
 In this case, transactions that attempt to modify an object that was modified by a different connection will raise an exception and can be retried.
 
-`~safir.database.create_database_engine` and the ``initialize`` method of `~safir.dependencies.db_session.db_session_dependency` take an optional ``isolation_level`` argument that can be used to set a non-default isolation level.
+`create_database_engine` and the ``initialize`` method of `~safir.dependencies.db_session.db_session_dependency` take an optional ``isolation_level`` argument that can be used to set a non-default isolation level.
 If given, this parameter is passed through to the underlying SQLAlchemy engine.
 
 See `the SQLAlchemy isolation level documentation <https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#setting-transaction-isolation-levels-dbapi-autocommit>`__ for more information.
@@ -20,9 +22,9 @@ See :doc:`dependency` and :doc:`session` for more information about initializing
 Retrying transactions
 =====================
 
-To retry failed transactions in a function or method, decorate that function or method with `~safir.database.retry_async_transaction`.
+To retry failed transactions in a function or method, decorate that function or method with `retry_async_transaction`.
 
-If the decorated function or method raises `sqlalchemy.exc.DBAPIError` (the parent exception for exceptions raised by the underlying database API), it will be re-ran with the same arguments.
+If the decorated function or method raises `sqlalchemy.exc.InterfaceError` or `sqlalchemy.exc.DBAPIError` (the parent exception for exceptions raised by the underlying database API), it will be re-ran with the same arguments.
 This will be repeated a configurable number of times (three by default).
 The decorated function or method must therefore be idempotent and safe to run repeatedly.
 

--- a/docs/user-guide/database/session.rst
+++ b/docs/user-guide/database/session.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: safir.database
+
 ###########################
 Creating a database session
 ###########################
@@ -6,6 +8,9 @@ Most applications will use database sessions in the context of a FastAPI handler
 See :doc:`dependency` for more details.
 
 This page describes how to get a database session outside of a FastAPI route handler, such as for cron jobs, background processing, or other non-web-application uses.
+
+Basic session creation
+======================
 
 To get a new async database connection, use code like the following:
 
@@ -17,7 +22,7 @@ To get a new async database connection, use code like the following:
    from .config import config
 
    engine = create_database_engine(
-       config.database_url, config.database_password
+       config.database_url, config.database_password, pool_pre_ping=True
    )
    session = await create_async_session(engine)
 
@@ -29,16 +34,30 @@ To get a new async database connection, use code like the following:
 Creating the engine is separate from creating the session so that the engine can be disposed of properly.
 This ensures the connection pool is closed.
 
-The ``connect_args``, ``max_overflow``, ``pool_size``, and ``pool_timeout`` parameters to `~safir.database.create_database_engine` have the same meaning as the corresponding arguments to `sqlalchemy.create_engine`.
+.. _db-engine-parameters:
+
+Engine parameters
+=================
+
+The ``connect_args``, ``max_overflow``, ``pool_pre_ping``, ``pool_recycle``, ``pool_size``, and ``pool_timeout`` parameters to `create_database_engine` have the same meaning as the corresponding arguments to `sqlalchemy.create_engine`.
+
+If the database client will only be interacting with the database intermittantly, consider setting ``pool_pre_ping=True`` in the parameters to `create_database_engine`.
+This will verify that a connection is still open before reusing it for a session.
+If it is not, a new connection will be opened without raising an exception that the caller has to catch.
+
+See :doc:`retry` for more information about retrying database transaction failures.
+
+If the connection idle timeout for the underlying database server is known, set ``pool_recycle`` to slightly less than that idle timeout in seconds.
+SQLAlchemy will then refuse to reuse any connection that has been open for longer than that period and will instead create a new connection.
 
 .. _probing-db-connection:
 
 Probing the database connection
 ===============================
 
-`~safir.database.create_async_session` supports probing the database to ensure that it is accessible and the schema is set up correctly.
+`create_async_session` supports probing the database to ensure that it is accessible and the schema is set up correctly.
 
-To do this, pass a SQL statement to execute as the ``statement`` argument to `~safir.database.create_async_session`.
+To do this, pass a SQL statement to execute as the ``statement`` argument to `create_async_session`.
 This will be called with ``.limit(1)`` to test the resulting session.
 When ``statement`` is provided, a `structlog`_ logger must also be provided to log any errors when trying to run the statement.
 

--- a/src/safir/database/_connection.py
+++ b/src/safir/database/_connection.py
@@ -90,6 +90,8 @@ def create_database_engine(
     connect_args: dict[str, Any] | None = None,
     isolation_level: str | None = None,
     max_overflow: int | None = None,
+    pool_pre_ping: bool | None = None,
+    pool_recycle: int | None = None,
     pool_size: int | None = None,
     pool_timeout: float | None = None,
 ) -> AsyncEngine:
@@ -109,6 +111,14 @@ def create_database_engine(
         engine.
     max_overflow
         Maximum number of connections over the pool size for surge traffic.
+    pool_pre_ping
+        Check that a connection is alive before returning it to a session.
+    pool_recycle
+        If set to an integer, discard any idle connection open for longer
+        than the provided number of seconds rather than attempting to reuse
+        it. If the connection idle timeout on the database server is known,
+        setting this to slightly less than that timeout will produce the
+        best results.
     pool_size
         Connection pool size.
     pool_timeout
@@ -134,6 +144,10 @@ def create_database_engine(
         kwargs["isolation_level"] = isolation_level
     if max_overflow is not None:
         kwargs["max_overflow"] = max_overflow
+    if pool_pre_ping is not None:
+        kwargs["pool_pre_ping"] = pool_pre_ping
+    if pool_recycle is not None:
+        kwargs["pool_recycle"] = pool_recycle
     if pool_size is not None:
         kwargs["pool_size"] = pool_size
     if pool_timeout is not None:

--- a/src/safir/database/_retry.py
+++ b/src/safir/database/_retry.py
@@ -7,7 +7,7 @@ from functools import wraps
 from typing import overload
 
 try:
-    from sqlalchemy.exc import DBAPIError
+    from sqlalchemy.exc import DBAPIError, InterfaceError
 except ImportError as e:
     raise ImportError(
         "The safir.database module requires the db extra. "
@@ -47,15 +47,17 @@ def retry_async_transaction[**P, T](
 ):
     """Retry if a transaction failed.
 
-    If the wrapped method fails with an `sqlalchemy.exc.DBAPIError` exception,
-    it is retried up to ``max_tries`` times. Any method with this decorator
-    must be idempotent, since it may be re-run multiple times.
+    If the wrapped method fails with an `sqlalchemy.exc.DBAPIError` or
+    `sqlalchemy.exc.InterfaceError` exception, it is retried up to
+    ``max_tries`` times. Any method with this decorator must be idempotent,
+    since it may be re-run multiple times.
 
-    One common use for this decorator is when the database engine has been
-    configured with the ``REPEATABLE READ`` transaction isolation level and
-    multiple writers may be updating the same object at the same time. The
-    loser of the transaction race will raise one of the above exceptions, and
-    can be retried with this decorator.
+    Besides handling unexpected database connection drops, one common use for
+    this decorator is when the database engine has been configured with the
+    ``REPEATABLE READ`` transaction isolation level and multiple writers may
+    be updating the same object at the same time. The loser of the transaction
+    race will raise `sqlalchemy.exc.DBAPIError` and can be retried with this
+    decorator.
 
     Parameters
     ----------
@@ -99,7 +101,7 @@ def retry_async_transaction[**P, T](
         @wraps(f)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             for _ in range(1, max_tries):
-                with contextlib.suppress(DBAPIError):
+                with contextlib.suppress(DBAPIError, InterfaceError):
                     return await f(*args, **kwargs)
                 await asyncio.sleep(delay)
             return await f(*args, **kwargs)

--- a/src/safir/dependencies/db_session.py
+++ b/src/safir/dependencies/db_session.py
@@ -74,6 +74,8 @@ class DatabaseSessionDependency:
         connect_args: dict[str, Any] | None = None,
         isolation_level: str | None = None,
         max_overflow: int | None = None,
+        pool_pre_ping: bool | None = None,
+        pool_recycle: int | None = None,
         pool_size: int | None = None,
         pool_timeout: float | None = None,
     ) -> None:
@@ -94,6 +96,14 @@ class DatabaseSessionDependency:
         max_overflow
             Maximum number of connections over the pool size for surge
             traffic.
+        pool_pre_ping
+            Check that a connection is alive before returning it to a session.
+        pool_recycle
+            If set to an integer, discard any idle connection open for longer
+            than the provided number of seconds rather than attempting to
+            reuse it. If the connection idle timeout on the database server is
+            known, setting this to slightly less than that timeout will
+            produce the best results.
         pool_size
             Connection pool size.
         pool_timeout
@@ -102,18 +112,17 @@ class DatabaseSessionDependency:
         """
         if self._engine:
             await self._engine.dispose()
-        kwargs: dict[str, Any] = {}
-        if connect_args:
-            kwargs["connect_args"] = connect_args
-        if isolation_level:
-            kwargs["isolation_level"] = isolation_level
-        if max_overflow is not None:
-            kwargs["max_overflow"] = max_overflow
-        if pool_size is not None:
-            kwargs["pool_size"] = pool_size
-        if pool_timeout is not None:
-            kwargs["pool_timeout"] = pool_timeout
-        self._engine = create_database_engine(url, password, **kwargs)
+        self._engine = create_database_engine(
+            url,
+            password,
+            connect_args=connect_args,
+            isolation_level=isolation_level,
+            max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
+            pool_recycle=pool_recycle,
+            pool_size=pool_size,
+            pool_timeout=pool_timeout,
+        )
         self._sessionmaker = async_sessionmaker(
             self._engine, expire_on_commit=False
         )


### PR DESCRIPTION
Add the `pool_pre_ping` and `pool_recycle` parameters to `create_database_engine` and the database session FastAPI dependency with the same meanings and defaults as in SQLAlchemy. Recommend using `pool_pre_ping=True` in applications that only use the database intermittently.

Add `InterfaceError` to the exceptions caught and retried by `@retry_async_transaction` so that it can be used to protect against database connection drops.

Fixes #552